### PR TITLE
oauth.getToken fix

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -35,13 +35,13 @@ oauth.getToken = function(code,done) {
 
     var endpoint = 'oauth/token'
         , args = {}
-        , body = {
+        , form = {
             code: code
             , client_secret: util.config.client_secret
             , client_id: util.config.client_id
         };
 
-    args.body = body;
+    args.form = form;
     util.postEndpoint(endpoint,args,done);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-v3",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Simple wrapper for strava v3 api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changing oauth.getToken to send the code, client_id, and client_secret
as a form, not as the body.
