### PR TITLE
Adding Club API Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ Clubs:
 * `strava.clubs.get(args,done)`
 * `strava.clubs.listMembers(args,done)`
 * `strava.clubs.listActivities(args,done)`
+* `strava.clubs.listAnnouncements(args,done)`
+* `strava.clubs.listEvents(args,done)`
+* `strava.clubs.listAdmins(args,done)`
+* `strava.clubs.joinClub(args,done)`
+* `strava.clubs.leaveClub(args,done)`
 
 Gear:
 * `strava.gear.get(args,done)`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# strava-v3: Simple Node wrapper for Strava's v3 API
+# node-strava-v3-advance: Simple Node wrapper for Strava's v3 API w/ Advanced Features
 
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 
 # node-strava-v3-advance: Simple Node wrapper for Strava's v3 API w/ Advanced Features
 
-[![NPM Version][npm-image]][npm-url]
-[![NPM Downloads][downloads-image]][downloads-url]
-[![Build Status][travis-image]][travis-url]
-
-[npm-image]: https://img.shields.io/npm/v/strava-v3.svg?style=flat
-[npm-url]: https://npmjs.org/package/strava-v3
-[downloads-image]: https://img.shields.io/npm/dm/strava-v3.svg?style=flat
-[downloads-url]: https://npmjs.org/package/strava-v3
-[travis-image]: https://travis-ci.org/UnbounDev/node-strava-v3.svg?branch=master&style=flat
-[travis-url]: https://travis-ci.org/UnbounDev/node-strava-v3
-
 ###(in development) Standard Node Strava V3 API with Advanced Features
 
 * Capture more than 200 results into one output file

--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ Clubs:
 * `strava.clubs.listAdmins(args,done)`
 * `strava.clubs.joinClub(args,done)`
 * `strava.clubs.leaveClub(args,done)`
+* `strava.clubs.listAnnouncements(args,done)`
+* `strava.clubs.listEvents(args,done)`
+* `strava.clubs.listAdmins(args,done)`
+* `strava.clubs.joinClub(args,done)`
+* `strava.clubs.leaveClub(args,done)`
 
 Gear:
 * `strava.gear.get(args,done)`

--- a/README.md
+++ b/README.md
@@ -194,11 +194,6 @@ Clubs:
 * `strava.clubs.listAdmins(args,done)`
 * `strava.clubs.joinClub(args,done)`
 * `strava.clubs.leaveClub(args,done)`
-* `strava.clubs.listAnnouncements(args,done)`
-* `strava.clubs.listEvents(args,done)`
-* `strava.clubs.listAdmins(args,done)`
-* `strava.clubs.joinClub(args,done)`
-* `strava.clubs.leaveClub(args,done)`
 
 Gear:
 * `strava.gear.get(args,done)`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 [travis-image]: https://travis-ci.org/UnbounDev/node-strava-v3.svg?branch=master&style=flat
 [travis-url]: https://travis-ci.org/UnbounDev/node-strava-v3
 
+###(in development) Standard Node Strava V3 API with Advanced Features
+
+* Capture more than 200 results into one output file
+* Only return filtered results by date/athlete/segment
+
 ### Status
 Supports API functionality for all API endpoints from `oauth` to `uploads`:
 
@@ -30,7 +35,7 @@ Supports API functionality for all API endpoints from `oauth` to `uploads`:
 ## Installation
 
 ```bash
-		npm install strava-v3
+		npm install strava-v3-advance
 ```
 
 ## Quick start

--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -28,6 +28,26 @@ clubs.listActivities = function(args,done) {
 
     this._listHelper('activities',args,done);
 };
+clubs.listAnnouncements = function(args,done) {
+
+    this._listHelper('announcements',args,done);
+};
+clubs.listClubEvents = function(args,done) {
+
+    this._listHelper('group_events',args,done);
+};
+clubs.listAdmins = function(args,done) {
+
+    this._listHelper('admins',args,done);
+};
+clubs.joinClub = function(args,done) {
+
+    this._listHelper('join',args,done);
+};
+clubs.leaveClub = function(args,done) {
+
+    this._listHelper('leave',args,done);
+};
 //===== clubs endpoint =====
 
 //===== helpers =====

--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -32,7 +32,7 @@ clubs.listAnnouncements = function(args,done) {
 
     this._listHelper('announcements',args,done);
 };
-clubs.listClubEvents = function(args,done) {
+clubs.listEvents = function(args,done) {
 
     this._listHelper('group_events',args,done);
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "strava-v3",
+  "name": "strava-v3-advance",
   "version": "1.10.0",
   "description": "Simple wrapper for strava v3 api",
   "main": "index.js",


### PR DESCRIPTION
Added the missing Club options for the Strava API to the Node Strava API plus corresponding entries on the Readme file.

Including:

list announcements, list group events, list club admins, join club, leave club