### PR TITLE
Refactor authentication into separate object

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,26 +19,6 @@ var fs = require('fs')
     ;
 
 var strava = {};
-var configPath = "data/strava_config";
-
-//attempt to grab the default config
-try {
-    var config = fs.readFileSync(configPath, {encoding: 'utf-8'});
-    util.config = JSON.parse(config);
-} catch (err) {
-    //console.log(err)
-    console.log("no 'data/strava_config' file, continuing without...");
-}
-
-//allow environment vars to override config vals
-if(process.env.STRAVA_ACCESS_TOKEN)
-  util.config.access_token = process.env.STRAVA_ACCESS_TOKEN;
-if(process.env.STRAVA_CLIENT_SECRET)
-  util.config.client_secret = process.env.STRAVA_CLIENT_SECRET;
-if(process.env.STRAVA_CLIENT_ID)
-  util.config.client_id = process.env.STRAVA_CLIENT_ID;
-if(process.env.STRAVA_REDIRECT_URI)
-  util.config.redirect_uri = process.env.STRAVA_REDIRECT_URI;
 
 //assign various api segments to strava object
 strava.oauth = oauth;
@@ -55,4 +35,3 @@ strava.routes = routes;
 
 //and export
 module.exports = strava;
-

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -12,8 +12,8 @@ var readConfigFile = function() {
       var config = fs.readFileSync(configPath, {encoding: 'utf-8'});
       config = JSON.parse(config);
       if(config.access_token) token = config.access_token;
-      if(config.client_id) clientId = config.clientId;
-      if(config.client_secret) clientSecret = config.clientSecret;
+      if(config.client_id) clientId = config.client_id;
+      if(config.client_secret) clientSecret = config.client_secret;
       if(config.redirect_uri) redirectUri = config.redirect_uri;
   } catch (err) {
     // Config file does not exist. This may be a valid case if the config is
@@ -85,7 +85,7 @@ module.exports = {
             console.log('No redirectUri found');
             return undefined;
         }
-    }
+    },
     purge: function() {
       token = undefined;
       clientId = undefined;

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -46,7 +46,6 @@ module.exports = {
         if(token) {
           return token;
         } else {
-          console.log('No logon token found');
           return undefined;
         }
     },

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('fs');
 
 var configPath = 'data/strava_config';
 
@@ -19,19 +19,23 @@ var readConfigFile = function() {
     // Config file does not exist. This may be a valid case if the config is
     // either passed directly as an argument or via environment variables
   }
-}
+};
 
 var readEnvironmentVars = function() {
-  if(process.env.STRAVA_ACCESS_TOKEN) token = process.env.STRAVA_ACCESS_TOKEN;
-  if(process.env.STRAVA_CLIENT_SECRET) clientId = process.env.STRAVA_CLIENT_SECRET;
-  if(process.env.STRAVA_CLIENT_ID) clientId = process.env.STRAVA_CLIENT_ID;
-  if(process.env.STRAVA_REDIRECT_URI) redirectUri = process.env.STRAVA_REDIRECT_URI;
-}
+  if(typeof process.env.STRAVA_ACCESS_TOKEN !== 'undefined')
+      token = process.env.STRAVA_ACCESS_TOKEN;
+  if(typeof process.env.STRAVA_CLIENT_ID !== 'undefined')
+      clientId = process.env.STRAVA_CLIENT_ID;
+  if(typeof process.env.STRAVA_CLIENT_SECRET !== 'undefined')
+      clientSecret = process.env.STRAVA_CLIENT_SECRET;
+  if(typeof process.env.STRAVA_REDIRECT_URI !== 'undefined')
+      redirectUri = process.env.STRAVA_REDIRECT_URI;
+};
 
 var fetchToken = function() {
   readConfigFile();
   readEnvironmentVars();
-}
+};
 
 module.exports = {
     getToken: function() {
@@ -42,8 +46,14 @@ module.exports = {
         if(token) {
           return token;
         } else {
-          console.log('No logon token found')
+          console.log('No logon token found');
           return undefined;
         }
+    },
+    purge: function() {
+      token = undefined;
+      clientId = undefined;
+      clientSecret = undefined;
+      redirectUri = undefined;
     }
 };

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -32,7 +32,7 @@ var readEnvironmentVars = function() {
       redirectUri = process.env.STRAVA_REDIRECT_URI;
 };
 
-var fetchToken = function() {
+var fetchConfig = function() {
   readConfigFile();
   readEnvironmentVars();
 };
@@ -40,7 +40,7 @@ var fetchToken = function() {
 module.exports = {
     getToken: function() {
         if(!token) {
-          fetchToken();
+          fetchConfig();
         }
 
         if(token) {
@@ -50,6 +50,42 @@ module.exports = {
           return undefined;
         }
     },
+    getClientId: function() {
+        if(!clientId) {
+            fetchConfig();
+        }
+
+        if(clientId) {
+          return clientId;
+        } else {
+          console.log('No client id found');
+          return undefined;
+        }
+    },
+    getClientSecret: function() {
+        if(!clientSecret) {
+            fetchConfig();
+        }
+
+        if(clientSecret) {
+            return clientSecret;
+        } else {
+            console.log('No client secret found');
+            return undefined;
+        }
+    },
+    getRedirectUri: function() {
+        if(!redirectUri) {
+            fetchConfig();
+        }
+
+        if(redirectUri) {
+            return redirectUri;
+        } else {
+            console.log('No redirectUri found');
+            return undefined;
+        }
+    }
     purge: function() {
       token = undefined;
       clientId = undefined;

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -1,0 +1,49 @@
+var fs = require('fs')
+
+var configPath = 'data/strava_config';
+
+var token;
+var clientId;
+var clientSecret;
+var redirectUri;
+
+var readConfigFile = function() {
+  try {
+      var config = fs.readFileSync(configPath, {encoding: 'utf-8'});
+      config = JSON.parse(config);
+      if(config.access_token) token = config.access_token;
+      if(config.client_id) clientId = config.clientId;
+      if(config.client_secret) clientSecret = config.clientSecret;
+      if(config.redirect_uri) redirectUri = config.redirect_uri;
+  } catch (err) {
+    // Config file does not exist. This may be a valid case if the config is
+    // either passed directly as an argument or via environment variables
+  }
+}
+
+var readEnvironmentVars = function() {
+  if(process.env.STRAVA_ACCESS_TOKEN) token = process.env.STRAVA_ACCESS_TOKEN;
+  if(process.env.STRAVA_CLIENT_SECRET) clientId = process.env.STRAVA_CLIENT_SECRET;
+  if(process.env.STRAVA_CLIENT_ID) clientId = process.env.STRAVA_CLIENT_ID;
+  if(process.env.STRAVA_REDIRECT_URI) redirectUri = process.env.STRAVA_REDIRECT_URI;
+}
+
+var fetchToken = function() {
+  readConfigFile();
+  readEnvironmentVars();
+}
+
+module.exports = {
+    getToken: function() {
+        if(!token) {
+          fetchToken();
+        }
+
+        if(token) {
+          return token;
+        } else {
+          console.log('No logon token found')
+          return undefined;
+        }
+    }
+};

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -3,6 +3,7 @@
  */
 
 var util = require('./util')
+    , authenticator = require('./authenticator')
     , request = require('request')
     , querystring = require('querystring');
 
@@ -12,8 +13,8 @@ oauth.getRequestAccessURL = function(args) {
 
     var url = 'https://www.strava.com/oauth/authorize?'
         , oauthArgs = {
-            client_id: util.config.client_id
-            , redirect_uri: util.config.redirect_uri
+            client_id: authenticator.getClientId()
+            , redirect_uri: authenticator.getRedirectUri()
             , response_type: 'code'
         };
 
@@ -23,7 +24,6 @@ oauth.getRequestAccessURL = function(args) {
         oauthArgs.state = args.state;
     if(args.approval_prompt)
         oauthArgs.approval_prompt = args.approval_prompt;
-
 
     var qs = querystring.stringify(oauthArgs);
 
@@ -37,8 +37,8 @@ oauth.getToken = function(code,done) {
         , args = {}
         , form = {
             code: code
-            , client_secret: util.config.client_secret
-            , client_id: util.config.client_id
+            , client_secret: authenticator.getClientSecret()
+            , client_id: authenticator.getClientId()
         };
 
     args.form = form;

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,14 +4,14 @@
 
 var request = require('request')
     , querystring = require('querystring')
-    , fs = require('fs');
+    , fs = require('fs')
+    , authenticator = require('./authenticator');
 
 //request.debug = true
 
 var util = {};
 
 util.endpointBase = 'https://www.strava.com/api/v3/';
-util.config = {};
 
 //===== generic GET =====
 util.getEndpoint = function(endpoint,args,done) {
@@ -20,21 +20,14 @@ util.getEndpoint = function(endpoint,args,done) {
         args = {};
     }
 
-    //all strava requests require an access_token, so let's do that check here
-    if (typeof args.access_token === 'undefined' && !this.config.access_token) {
-        return done({'msg': 'you must include an access_token'});
-    }
-    //add in default access_token, if not overwritten by args
-    else if (typeof args.access_token === 'undefined') {
-        args.access_token = this.config.access_token;
-    }
+    var token = args.access_token || authenticator.getToken();
 
     var url = this.endpointBase + endpoint
         , options = {
             url: url
             , json: true
             , headers: {
-                Authorization: 'Bearer ' + args.access_token
+                Authorization: 'Bearer ' + token
             }
         };
 
@@ -48,14 +41,7 @@ util.putEndpoint = function(endpoint,args,done) {
         args = {};
     }
 
-    //all strava requests require an access_token, so let's do that check here
-    if (typeof args.access_token === 'undefined' && !this.config.access_token) {
-        return done({'msg': 'you must include an access_token'});
-    }
-    //add in default access_token, if not overwritten by args
-    else if (typeof args.access_token === 'undefined') {
-        args.access_token = this.config.access_token;
-    }
+    var token = args.access_token || authenticator.getToken();
 
     //stringify the body object for passage
     var qs = querystring.stringify(args.body);
@@ -67,7 +53,7 @@ util.putEndpoint = function(endpoint,args,done) {
             , json: true
             , body: qs
             , headers: {
-                Authorization: 'Bearer ' + args.access_token
+                Authorization: 'Bearer ' + token
             }
         };
 
@@ -85,14 +71,7 @@ util.postEndpoint = function(endpoint,args,done) {
         args = {};
     }
 
-    //all strava requests require an access_token, so let's do that check here
-    if (typeof args.access_token === 'undefined' && !this.config.access_token) {
-        return done({'msg': 'you must include an access_token'});
-    }
-    //add in default access_token, if not overwritten by args
-    else if (typeof args.access_token === 'undefined') {
-        args.access_token = this.config.access_token;
-    }
+    var token = args.access_token || authenticator.getToken();
 
     //stringify the body object for passage
     //var qs = querystring.stringify(args.body);
@@ -104,7 +83,7 @@ util.postEndpoint = function(endpoint,args,done) {
             , json: true
             , body: args.body
             , headers: {
-                Authorization: 'Bearer ' + args.access_token
+                Authorization: 'Bearer ' + token
             }
         };
 
@@ -126,14 +105,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
         args = {};
     }
 
-    //all strava requests require an access_token, so let's do that check here
-    if (typeof args.access_token === 'undefined' && !this.config.access_token) {
-        return done({'msg': 'you must include an access_token'});
-    }
-    //add in default access_token, if not overwritten by args
-    else if (typeof args.access_token === 'undefined') {
-        args.access_token = this.config.access_token;
-    }
+    var token = args.access_token || authenticator.getToken();
 
     //stringify the body object for passage
     var qs = querystring.stringify(args.body);
@@ -145,7 +117,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
             , json: true
             , body: qs
             , headers: {
-                Authorization: 'Bearer ' + args.access_token
+                Authorization: 'Bearer ' + token
             }
         };
 
@@ -155,14 +127,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
 //===== postUpload =====
 util.postUpload = function(args,done) {
 
-    //all strava requests require an access_token, so let's do that check here
-    if (typeof args.access_token === 'undefined' && !this.config.access_token) {
-        return done({'msg': 'you must include an access_token'});
-    }
-    //add in default access_token, if not overwritten by args
-    else if (typeof args.access_token === 'undefined') {
-        args.access_token = this.config.access_token;
-    }
+    var token = args.access_token || authenticator.getToken();
 
     var url = this.endpointBase + 'uploads'
         , options = {
@@ -170,7 +135,7 @@ util.postUpload = function(args,done) {
             , method: 'POST'
             , json: true
             , headers: {
-                Authorization: 'Bearer ' + args.access_token
+                Authorization: 'Bearer ' + token
             }
         };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,6 +21,7 @@ util.getEndpoint = function(endpoint,args,done) {
     }
 
     var token = args.access_token || authenticator.getToken();
+    if(!token) return done({msg: 'you must include an access_token'});
 
     var url = this.endpointBase + endpoint
         , options = {
@@ -42,6 +43,7 @@ util.putEndpoint = function(endpoint,args,done) {
     }
 
     var token = args.access_token || authenticator.getToken();
+    if(!token) return done({msg: 'you must include an access_token'});
 
     //stringify the body object for passage
     var qs = querystring.stringify(args.body);
@@ -72,6 +74,7 @@ util.postEndpoint = function(endpoint,args,done) {
     }
 
     var token = args.access_token || authenticator.getToken();
+    if(!token) return done({msg: 'you must include an access_token'});
 
     //stringify the body object for passage
     //var qs = querystring.stringify(args.body);
@@ -106,6 +109,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
     }
 
     var token = args.access_token || authenticator.getToken();
+    if(!token) return done({msg: 'you must include an access_token'});
 
     //stringify the body object for passage
     var qs = querystring.stringify(args.body);
@@ -128,6 +132,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
 util.postUpload = function(args,done) {
 
     var token = args.access_token || authenticator.getToken();
+    if(!token) return done({msg: 'you must include an access_token'});
 
     var url = this.endpointBase + 'uploads'
         , options = {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt-simple-mocha": "^0.4.0",
     "mocha": "^1.21.5",
     "should": "^4.6.5",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.4",
+    "mock-fs": "^3.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-simple-mocha": "^0.4.0",
     "mocha": "^1.21.5",
-    "should": "^4.6.5"
+    "should": "^4.6.5",
+    "sinon": "^1.17.4"
   }
 }

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -2,6 +2,7 @@
  * Created by austin on 9/27/14.
  */
 
+var fs = require('fs');
 var strava = require('../');
 
 var testsHelper = {};
@@ -58,5 +59,10 @@ testsHelper.getSampleSegment = function(done) {
         done(err,payload.segment);
     });
 };
+
+testsHelper.getAccessToken = function() {
+  var config = fs.readFileSync('data/strava_config', {encoding: 'utf-8'});
+  return JSON.parse(config).access_token;
+}
 
 module.exports = testsHelper;

--- a/test/activities.js
+++ b/test/activities.js
@@ -3,8 +3,10 @@
  */
 
 var should = require("should")
+    , sinon = require('sinon')
     , strava = require("../")
-    , testHelper = require("./_helper");
+    , testHelper = require("./_helper")
+    , authenticator = require('../lib/authenticator');
 
 var testActivity = {}
     , _sampleActivityPreEdit
@@ -65,6 +67,20 @@ describe('activities_test', function() {
 
                 done();
 
+            });
+        });
+
+        it('should work with a specified access token', function(done) {
+            var token = testHelper.getAccessToken();
+            var tokenStub = sinon.stub(authenticator, 'getToken', () => undefined);
+
+            strava.activities.get({
+              id: testActivity.id,
+              access_token: token
+            }, function(err, payload) {
+              (payload.resource_state).should.be.exactly(3);
+              tokenStub.restore();
+              done();
             });
         });
     });

--- a/test/activities.js
+++ b/test/activities.js
@@ -72,7 +72,9 @@ describe('activities_test', function() {
 
         it('should work with a specified access token', function(done) {
             var token = testHelper.getAccessToken();
-            var tokenStub = sinon.stub(authenticator, 'getToken', () => undefined);
+            var tokenStub = sinon.stub(authenticator, 'getToken', function () {
+                return undefined;
+            });
 
             strava.activities.get({
               id: testActivity.id,

--- a/test/authenticator.js
+++ b/test/authenticator.js
@@ -1,0 +1,47 @@
+
+var should = require('should')
+    , mockFS = require('mock-fs')
+    , authenticator = require('../lib/authenticator');
+    var testHelper = require('./_helper')
+
+describe('authenticator_test', function() {
+    describe('getToken()', function() {
+        it('should read the access token from the config file', function() {
+            mockFS({
+                'data/strava_config': JSON.stringify({
+                    'access_token': 'abcdefghi',
+                    'client_id': 'jklmnopqr',
+                    'client_secret': 'stuvwxyz',
+                    'redirect_uri': 'https://sample.com'
+                })
+            });
+            var envAccessToken = process.env.access_token;
+            delete process.env.STRAVA_ACCESS_TOKEN;
+
+            authenticator.purge();
+
+            (authenticator.getToken()).should.be.exactly('abcdefghi');
+
+            mockFS.restore();
+            process.env.STRAVA_ACCESS_TOKEN = envAccessToken;
+
+            authenticator.purge();
+        });
+
+        it('should read the access token from the env vars', function() {
+            mockFS({
+                'data': {}
+            });
+            process.env.STRAVA_ACCESS_TOKEN = 'abcdefghi';
+
+            authenticator.purge();
+
+            (authenticator.getToken()).should.be.exactly('abcdefghi');
+
+            mockFS.restore();
+            delete process.env.STRAVA_ACCESS_TOKEN;
+
+            authenticator.purge();
+        });
+    });
+});

--- a/test/authenticator.js
+++ b/test/authenticator.js
@@ -5,7 +5,7 @@ var should = require('should')
     var testHelper = require('./_helper')
 
 describe('authenticator_test', function() {
-    describe('getToken()', function() {
+    describe('#getToken()', function() {
         it('should read the access token from the config file', function() {
             mockFS({
                 'data/strava_config': JSON.stringify({
@@ -15,16 +15,12 @@ describe('authenticator_test', function() {
                     'redirect_uri': 'https://sample.com'
                 })
             });
-            var envAccessToken = process.env.access_token;
             delete process.env.STRAVA_ACCESS_TOKEN;
-
             authenticator.purge();
 
             (authenticator.getToken()).should.be.exactly('abcdefghi');
 
             mockFS.restore();
-            process.env.STRAVA_ACCESS_TOKEN = envAccessToken;
-
             authenticator.purge();
         });
 
@@ -40,6 +36,114 @@ describe('authenticator_test', function() {
 
             mockFS.restore();
             delete process.env.STRAVA_ACCESS_TOKEN;
+
+            authenticator.purge();
+        });
+    });
+
+    describe('#getClientId()', function() {
+        it('should read the client id from the config file', function() {
+            mockFS({
+                'data/strava_config': JSON.stringify({
+                    'access_token': 'abcdefghi',
+                    'client_id': 'jklmnopqr',
+                    'client_secret': 'stuvwxyz',
+                    'redirect_uri': 'https://sample.com'
+                })
+            });
+            delete process.env.STRAVA_CLIENT_ID;
+            authenticator.purge();
+
+            (authenticator.getClientId()).should.be.exactly('jklmnopqr');
+
+            mockFS.restore();
+            authenticator.purge();
+        });
+
+        it('should read the client id from the env vars', function() {
+            mockFS({
+                'data': {}
+            });
+            process.env.STRAVA_CLIENT_ID = 'abcdefghi';
+
+            authenticator.purge();
+
+            (authenticator.getClientId()).should.be.exactly('abcdefghi');
+
+            mockFS.restore();
+            delete process.env.STRAVA_CLIENT_ID;
+
+            authenticator.purge();
+        });
+    });
+
+    describe('#getClientSecret()', function() {
+        it('should read the client secret from the config file', function() {
+            mockFS({
+                'data/strava_config': JSON.stringify({
+                    'access_token': 'abcdefghi',
+                    'client_id': 'jklmnopqr',
+                    'client_secret': 'stuvwxyz',
+                    'redirect_uri': 'https://sample.com'
+                })
+            });
+            delete process.env.STRAVA_CLIENT_SECRET;
+            authenticator.purge();
+
+            (authenticator.getClientSecret()).should.be.exactly('stuvwxyz');
+
+            mockFS.restore();
+            authenticator.purge();
+        });
+
+        it('should read the client secret from the env vars', function() {
+            mockFS({
+                'data': {}
+            });
+            process.env.STRAVA_CLIENT_SECRET = 'abcdefghi';
+
+            authenticator.purge();
+
+            (authenticator.getClientSecret()).should.be.exactly('abcdefghi');
+
+            mockFS.restore();
+            delete process.env.STRAVA_CLIENT_SECRET;
+
+            authenticator.purge();
+        });
+    });
+
+    describe('#getRedirectUri()', function() {
+        it('should read the redirect URI from the config file', function() {
+            mockFS({
+                'data/strava_config': JSON.stringify({
+                    'access_token': 'abcdefghi',
+                    'client_id': 'jklmnopqr',
+                    'client_secret': 'stuvwxyz',
+                    'redirect_uri': 'https://sample.com'
+                })
+            });
+            delete process.env.STRAVA_REDIRECT_URI;
+            authenticator.purge();
+
+            (authenticator.getRedirectUri()).should.be.exactly('https://sample.com');
+
+            mockFS.restore();
+            authenticator.purge();
+        });
+
+        it('should read the redirect URI from the env vars', function() {
+            mockFS({
+                'data': {}
+            });
+            process.env.STRAVA_REDIRECT_URI = 'https://sample.com';
+
+            authenticator.purge();
+
+            (authenticator.getRedirectUri()).should.be.exactly('https://sample.com');
+
+            mockFS.restore();
+            delete process.env.STRAVA_REDIRECT_URI;
 
             authenticator.purge();
         });

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -2,34 +2,40 @@
  * Created by austin on 9/22/14.
  */
 
-
-
-var should = require("should")
-    , strava = require("../");
+var should = require('should')
+    , authenticator = require('../lib/authenticator')
+    , querystring = require('querystring')
+    , strava = require('../');
 
 var _tokenExchangeCode = "a248c4c5dc49e71336010022efeb3a268594abb7";
 
-describe.skip('oauth_test', function() {
-
+describe('oauth_test', function() {
     describe('#getRequestAccessURL()', function () {
+        it('should return the full request access url', function () {
+            var clientId = authenticator.getClientId();
+            var redirectUri = authenticator.getRedirectUri();
+            var targetUrl = 'https://www.strava.com/oauth/authorize?'
+                + querystring.stringify({
+                  client_id: authenticator.getClientId(),
+                  redirect_uri: authenticator.getRedirectUri(),
+                  response_type: 'code',
+                  scope: 'view_private,write'
+                });
 
-        it('should return the full request url for view_private and write permissions', function () {
+            var url = strava.oauth.getRequestAccessURL({
+              scope:"view_private,write"
+            });
 
-            var url = strava.oauth.getRequestAccessURL({scope:"view_private write"});
-            console.log(url);
-
+            url.should.be.exactly(targetUrl);
         });
     });
 
-    describe('#getToken()', function () {
-
+    // TODO: Figure out a way to get a valid oAuth code for the token exchange
+    describe.skip('#getToken()', function () {
         it('should return an access_token', function (done) {
-
             strava.oauth.getToken(_tokenExchangeCode,function(err,payload) {
-
                 done();
             });
-
         });
     });
 });


### PR DESCRIPTION
The way the authentication logic was build into the other modules made unit tests of the authentication itself and of service calls executed with a specific authentication type very hard.

Moving the authentication into a `authenticator` object not only better separates the concerns of the library, but also enables simple unit tests and mocking of the authentication.