### PR TITLE
Fix #18: Fix context issues for API function calls

### DIFF
--- a/lib/activities.js
+++ b/lib/activities.js
@@ -90,7 +90,7 @@ activities.delete = function(args,done) {
 activities.listFriends = function(args,done) {
 
     var endpoint = 'activities/following/';
-    this._listHelper(endpoint,args,done);
+    _listHelper(endpoint,args,done);
 };
 activities.listZones = function(args,done) {
 
@@ -105,7 +105,7 @@ activities.listZones = function(args,done) {
 
     endpoint += args.id + '/zones';
 
-    this._listHelper(endpoint,args,done);
+    _listHelper(endpoint,args,done);
 };
 activities.listLaps = function(args,done) {
 
@@ -120,7 +120,7 @@ activities.listLaps = function(args,done) {
 
     endpoint += args.id + '/laps';
 
-    this._listHelper(endpoint,args,done);
+    _listHelper(endpoint,args,done);
 };
 activities.listComments = function(args,done) {
 
@@ -135,7 +135,7 @@ activities.listComments = function(args,done) {
 
     endpoint += args.id + '/comments';
 
-    this._listHelper(endpoint,args,done);
+    _listHelper(endpoint,args,done);
 };
 activities.listKudos = function(args,done) {
 
@@ -150,34 +150,34 @@ activities.listKudos = function(args,done) {
 
     endpoint += args.id + '/kudos';
 
-    this._listHelper(endpoint,args,done);
+    _listHelper(endpoint,args,done);
 };
 activities.listPhotos = function(args,done) {
 
     var endpoint = 'activities/'
         , err = null;
-    
+
     //require activity id
     if (typeof args.id === 'undefined') {
         err = { msg: 'args must include an activity id' };
         return done(err);
     }
-    
+
     endpoint += args.id + '/photos';
-    
+
     var pageQS = util.getPaginationQS(args);
-    
+
     var completeQS = pageQS;
-    
+
     // should be true according to Strava API docs
     args.photo_sources = true;
     var argsQS = util.getQS(['size', 'photo_sources'], args);
-    
+
     if (completeQS && completeQS.length) {
         completeQS += '&';
     }
     completeQS += argsQS;
-    
+
     endpoint += '?' + completeQS;
 
     util.getEndpoint(endpoint, args, done);
@@ -194,12 +194,12 @@ activities.listRelated = function(args,done) {
 
     endpoint += args.id + '/related';
 
-    this._listHelper(endpoint,args,done);
+    _listHelper(endpoint,args,done);
 };
 //===== activities endpoint =====
 
 //===== helpers =====
-activities._listHelper = function(endpoint,args,done) {
+var _listHelper = function(endpoint,args,done) {
 
     var qs = util.getPaginationQS(args);
 

--- a/lib/athlete.js
+++ b/lib/athlete.js
@@ -31,23 +31,23 @@ athlete.get = function(args,done) {
 };
 athlete.listFriends = function(args,done) {
 
-    this._listHelper('friends',args,done);
+    _listHelper('friends',args,done);
 };
 athlete.listFollowers = function(args,done) {
 
-    this._listHelper('followers',args,done);
+    _listHelper('followers',args,done);
 };
 athlete.listActivities = function(args,done) {
 
-    this._listHelper('activities',args,done);
+    _listHelper('activities',args,done);
 };
 athlete.listClubs = function(args,done) {
 
-    this._listHelper('clubs',args,done);
+    _listHelper('clubs',args,done);
 };
 athlete.listRoutes = function(args,done) {
 
-    this._listHelper('routes',args,done);
+    _listHelper('routes',args,done);
 };
 
 athlete.update = function(args,done) {
@@ -61,7 +61,7 @@ athlete.update = function(args,done) {
 //===== athlete endpoint =====
 
 //===== helpers =====
-athlete._listHelper = function(listType,args,done) {
+var _listHelper = function(listType,args,done) {
 
     var endpoint = 'athlete/'
         , qs = util.getQS(_qsAllowedProps,args);

--- a/lib/athletes.js
+++ b/lib/athletes.js
@@ -10,28 +10,28 @@ var athletes = {};
 //===== athletes endpoint =====
 athletes.get = function(args,done) {
 
-    this._listHelper('',args,done);
+    _listHelper('',args,done);
 };
 athletes.listFriends = function(args,done) {
 
-    this._listHelper('friends',args,done);
+    _listHelper('friends',args,done);
 };
 athletes.listFollowers = function(args,done) {
 
-    this._listHelper('followers',args,done);
+    _listHelper('followers',args,done);
 };
 athletes.stats = function(args, done) {
 
-    this._listHelper('stats',args,done);
+    _listHelper('stats',args,done);
 };
 athletes.listKoms = function(args,done) {
 
-    this._listHelper('koms',args,done);
+    _listHelper('koms',args,done);
 };
 //===== athletes endpoint =====
 
 //===== helpers =====
-athletes._listHelper = function(listType,args,done) {
+var _listHelper = function(listType,args,done) {
 
     var endpoint = 'athletes/'
         , err = null

--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -22,36 +22,36 @@ clubs.get = function(args,done) {
 };
 clubs.listMembers = function(args,done) {
 
-    this._listHelper('members',args,done);
+    _listHelper('members',args,done);
 };
 clubs.listActivities = function(args,done) {
 
-    this._listHelper('activities',args,done);
+    _listHelper('activities',args,done);
 };
 clubs.listAnnouncements = function(args,done) {
 
-    this._listHelper('announcements',args,done);
+    _listHelper('announcements',args,done);
 };
 clubs.listEvents = function(args,done) {
 
-    this._listHelper('group_events',args,done);
+    _listHelper('group_events',args,done);
 };
 clubs.listAdmins = function(args,done) {
 
-    this._listHelper('admins',args,done);
+    _listHelper('admins',args,done);
 };
 clubs.joinClub = function(args,done) {
 
-    this._listHelper('join',args,done);
+    _listHelper('join',args,done);
 };
 clubs.leaveClub = function(args,done) {
 
-    this._listHelper('leave',args,done);
+    _listHelper('leave',args,done);
 };
 //===== clubs endpoint =====
 
 //===== helpers =====
-clubs._listHelper = function(listType,args,done) {
+var _listHelper = function(listType,args,done) {
 
     var endpoint = 'clubs/'
         , err = null

--- a/lib/segments.js
+++ b/lib/segments.js
@@ -56,12 +56,12 @@ segments.listStarred = function(args,done) {
 
 segments.listEfforts = function(args,done) {
 
-    this._listHelper('all_efforts',args,done);
+    _listHelper('all_efforts',args,done);
 };
 
 segments.listLeaderboard = function(args,done) {
 
-    this._listHelper('leaderboard',args,done);
+    _listHelper('leaderboard',args,done);
 };
 
 segments.explore = function(args,done) {
@@ -74,7 +74,7 @@ segments.explore = function(args,done) {
 //===== segments endpoint =====
 
 //===== helpers =====
-segments._listHelper = function(listType,args,done) {
+var _listHelper = function(listType,args,done) {
 
     var endpoint = 'segments/'
         , err = null

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -14,30 +14,30 @@ var streams = {}
 streams.activity = function(args,done) {
 
     var endpoint = 'activities';
-    this._typeHelper(endpoint,args,done);
+    _typeHelper(endpoint,args,done);
 };
 
 streams.effort = function(args,done) {
 
     var endpoint = 'segment_efforts';
-    this._typeHelper(endpoint,args,done);
+    _typeHelper(endpoint,args,done);
 };
 
 streams.segment = function(args,done) {
 
     var endpoint = 'segments';
-    this._typeHelper(endpoint,args,done);
+    _typeHelper(endpoint,args,done);
 };
 
 streams.route = function(args,done) {
 
     var endpoint = 'routes';
-    this._typeHelper(endpoint,args,done);
+    _typeHelper(endpoint,args,done);
 };
 //===== streams endpoint =====
 
 //===== helpers =====
-streams._typeHelper = function(endpoint,args,done) {
+var _typeHelper = function(endpoint,args,done) {
 
     var err = null
         , qs = util.getQS(_qsAllowedProps,args);

--- a/lib/util.js
+++ b/lib/util.js
@@ -32,7 +32,7 @@ util.getEndpoint = function(endpoint,args,done) {
             }
         };
 
-    this._requestHelper(options,done);
+    _requestHelper(options,done);
 };
 
 //===== generic PUT =====
@@ -63,7 +63,7 @@ util.putEndpoint = function(endpoint,args,done) {
     if(args.form)
         options.form = args.form;
 
-    this._requestHelper(options,done);
+    _requestHelper(options,done);
 };
 
 //===== generic POST =====
@@ -98,7 +98,7 @@ util.postEndpoint = function(endpoint,args,done) {
     if(args.multipart)
         options.multipart = args.multipart;
 
-    this._requestHelper(options,done);
+    _requestHelper(options,done);
 };
 
 //===== generic DELETE =====
@@ -125,7 +125,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
             }
         };
 
-    this._requestHelper(options,done);
+    _requestHelper(options,done);
 };
 
 //===== postUpload =====
@@ -208,7 +208,7 @@ util.getRequestBodyObj = function(allowedProps,args) {
 
 
 //===== helpers =====
-util._requestHelper = function(options,done) {
+var _requestHelper = function(options,done) {
 
     request(options, function (err, response, payload) {
 

--- a/test/activities.js
+++ b/test/activities.js
@@ -85,6 +85,19 @@ describe('activities_test', function() {
               done();
             });
         });
+
+        it('should run with a null context', function(done) {
+          strava.activities.get.call(null, {id: testActivity.id}, function (err, payload) {
+
+            if (!err) {
+              (payload.resource_state).should.be.exactly(3);
+            } else {
+              console.log(err);
+            }
+
+            done();
+          });
+        });
     });
 
     describe('#update()', function () {

--- a/test/athlete.js
+++ b/test/athlete.js
@@ -41,6 +41,18 @@ describe('athlete_test', function(){
                 done();
             });
         });
+
+        it('should run with a null context', function(done) {
+          strava.athlete.listFriends.call(null, {},function(err,payload){
+            if(!err) {
+              payload.should.be.instanceof(Array);
+            } else {
+              console.log(err);
+            }
+
+            done();
+          });
+        });
     });
 
     describe('#listFollowers()', function() {
@@ -150,6 +162,29 @@ describe('athlete_test', function(){
                     strava.athlete.update({city:_athletePreEdit.city},function(err,payload){
 
                         //console.log(payload);
+                        (payload.resource_state).should.be.exactly(3);
+                        (payload.city).should.be.exactly(_athletePreEdit.city);
+                        done();
+                    });
+                }
+                else {
+                    console.log(err);
+                    done();
+                }
+            });
+        });
+
+        it('should run with a null context', function(done) {
+
+            var city = "Barcelona";
+
+            strava.athlete.update.call(null, {city:city},function(err,payload){
+                if(!err) {
+                    (payload.resource_state).should.be.exactly(3);
+                    (payload.city).should.be.exactly(city);
+
+                    //great! we've proven our point, let's reset the athlete data
+                    strava.athlete.update({city:_athletePreEdit.city},function(err,payload){
                         (payload.resource_state).should.be.exactly(3);
                         (payload.city).should.be.exactly(_athletePreEdit.city);
                         done();

--- a/test/athletes.js
+++ b/test/athletes.js
@@ -31,6 +31,22 @@ describe('athletes', function(){
 
                 done();
             });
+        });
+
+        it('should run with a null context', function(done){
+
+            strava.athletes.get.call(null, {id:_sampleAthlete.id},function(err,payload){
+
+                if(!err) {
+                    //console.log(payload);
+                    (payload.resource_state).should.be.within(2,3);
+                }
+                else {
+                    console.log(err);
+                }
+
+                done();
+            });
         })
     });
 
@@ -85,7 +101,23 @@ describe('athletes', function(){
 
                 done();
             });
-        })
+        });
+
+        it('should run with a null context', function(done){
+
+            strava.athletes.stats.call(null, {id:_sampleAthlete.id},function(err,payload){
+
+                if(!err) {
+                    //console.log(payload);
+                    payload.should.have.property('biggest_ride_distance');
+                }
+                else {
+                    console.log(err);
+                }
+
+                done();
+            });
+        });
     });
 
     describe('#listKoms()',function(){

--- a/test/clubs.js
+++ b/test/clubs.js
@@ -35,6 +35,18 @@ describe('clubs_test', function() {
                 done();
             });
         });
+
+        it('should run with a null context', function(done) {
+          strava.clubs.get.call(null, {id:_sampleClub.id}, function(err,payload) {
+            if(!err) {
+              (payload.resource_state).should.be.exactly(3);
+            } else {
+              console.log(err);
+            }
+
+            done();
+          });
+        });
     });
 
     describe('#listMembers()', function () {
@@ -60,6 +72,21 @@ describe('clubs_test', function() {
         it('should return a list of club activities', function(done) {
 
             strava.clubs.listActivities({id:_sampleClub.id}, function(err,payload) {
+
+                if(!err) {
+                    //console.log(payload);
+                    payload.should.be.instanceof(Array);
+                }
+                else {
+                    console.log(err);
+                }
+                done();
+            });
+        });
+
+        it('should run with a null context', function(done) {
+
+            strava.clubs.listActivities.call(null, {id:_sampleClub.id}, function(err,payload) {
 
                 if(!err) {
                     //console.log(payload);

--- a/test/segments.js
+++ b/test/segments.js
@@ -33,6 +33,22 @@ describe.skip('segments_test', function() {
                 done();
             });
         });
+
+        it('should run with a null context', function (done) {
+
+            strava.segments.get.call(null, {id:_sampleSegment.id}, function (err, payload) {
+
+                if (!err) {
+                    //console.log(payload);
+                    (payload.resource_state).should.be.exactly(3);
+                }
+                else {
+                    console.log(err);
+                }
+
+                done();
+            });
+        });
     });
 
     describe('#listStarred()', function () {

--- a/test/streams.js
+++ b/test/streams.js
@@ -56,6 +56,26 @@ describe('streams_test', function() {
 
             });
         });
+
+        it('should run with a null context', function(done) {
+            strava.streams.activity.call(null, {
+                id: _activity_id
+                , types: 'time,distance'
+                , resolution: 'low'
+            }, function (err, payload) {
+
+                if (!err) {
+                    //console.log(payload);
+                    payload.should.be.instanceof(Array);
+                }
+                else {
+                    console.log(err);
+                }
+
+                done();
+
+            });
+        });
     });
 
     describe.skip('#effort()', function () {
@@ -108,6 +128,26 @@ describe('streams_test', function() {
 
         it('should return raw data associated to route', function(done) {
             strava.streams.route({
+                id: _route_id
+                , types: ''
+                , resolution: 'low'
+            }, function (err, payload) {
+
+                if (!err) {
+                    //console.log(payload);
+                    payload.should.be.instanceof(Array);
+                }
+                else {
+                    console.log(err);
+                }
+
+                done();
+
+            });
+        });
+
+        it('should run with a null context', function(done) {
+            strava.streams.route.call(null, {
                 id: _route_id
                 , types: ''
                 , resolution: 'low'


### PR DESCRIPTION
API calls used to fail when the functions were called with a different
context (`this`-assignment), e.g. as a callback. This prevented among
others the usage in the `async` module.

Removed the dependency on the correct context, also removed internal
functions from the module exports.

Fixes #18