### PR TITLE
Added segment starring endpoint

### DIFF
--- a/lib/segments.js
+++ b/lib/segments.js
@@ -27,6 +27,10 @@ var segments = {}
         , 'activity_type'
         , 'min_cat'
         , 'max_cat'
+    ]
+    , _updateAllowedProps = [
+        //star segment
+        'starred'
     ];
 
 //===== segments endpoint =====
@@ -52,6 +56,23 @@ segments.listStarred = function(args,done) {
         , endpoint = 'segments/starred?' + qs;
 
     util.getEndpoint(endpoint,args,done);
+};
+
+segments.starSegment = function(args,done) {
+
+    var endpoint = 'segments/'
+        , form = util.getRequestBodyObj(_updateAllowedProps,args)
+        , err = null;
+
+    if(typeof args.id === 'undefined') {
+        err = {msg:'args must include an segment id'};
+        return done(err);
+    }
+
+    endpoint += args.id + '/starred';
+    args.form = form;
+
+    util.putEndpoint(endpoint,args,done);
 };
 
 segments.listEfforts = function(args,done) {

--- a/test/segments.js
+++ b/test/segments.js
@@ -70,6 +70,35 @@ describe.skip('segments_test', function() {
         });
     });
 
+    describe('#starSegment()', function() {
+
+        it('should toggle starred segment', function (done) {
+
+            var args = {id: _sampleSegment.id, starred: !_sampleSegment.starred};
+            strava.segments.starSegment(args, function(err, payload) {
+
+                if (!err) {
+                    (payload.starred).should.be.exactly(!_sampleSegment.starred);
+                    // revert segment star status back to original
+                    args.starred = _sampleSegment.starred;
+                    strava.segments.starSegment(args, function(err, payload) {
+                        if (!err) {
+                            (payload.starred).should.be.exactly(_sampleSegment.starred);
+                        }
+                        else {
+                            console.log(err);
+                        }
+                    })
+                }
+                else {
+                    console.log(err);
+                }
+
+                done();
+            });
+        });
+    });
+
     describe('#listEfforts()', function () {
 
         it('should list efforts on segment by current athlete', function (done) {


### PR DESCRIPTION
Added support for segment starring endpoint (https://strava.github.io/api/v3/segments/#star), which was added to Strava API at August 31, 2016 according to the Strava API changelog.

Endpoint takes segment id and starred value (true/false) as arguments and updates starred value to Strava. So just one new method strava.segments.starSegment()

Created test which toggles sampleSegments starred value twice, so it should be original at the end of the test.