### PR TITLE
Added 'private' to allowed update properties

### DIFF
--- a/lib/activities.js
+++ b/lib/activities.js
@@ -26,6 +26,7 @@ var activities = {}
     , _updateAllowedProps = [
         'name'
         , 'type'
+        , 'private'
         , 'commute'
         , 'trainer'
         , 'description'


### PR DESCRIPTION
The 'private' property was either added to api later, or missed by this wrapper.
http://strava.github.io/api/v3/activities/#put-updates