### PR TITLE
Add Promise-based API. Fixes #46.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,18 @@ strava.oauth.getToken(code,function(err,payload,limits) {
 });
 ```
 
+Finally, the test suite has some expectations about the Strava account that it
+connects for the tests to pass. The following should be true about the Strava
+data in the account:
+
+ * Must have at least one activity posted on Strava
+ * Must have joined at least one club
+ * Must have added at least one piece of gear (bike or shoes)
+ * Must have created at least one route
+ * Most recent activity with an achievement should also contain a segment
+
+(Contributions to make the test suite more self-contained and robust are welcome!)
+
 * You're done! Paste the new `access_token` to `data/strava_config` and go run some tests:
 
 `grunt jshint simplemocha` or `npm test`.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ For more details see: [Rate Limiting](https://strava.github.io/api/#rate-limitin
 
 Returns `null` if `X-Ratelimit-Limit` or `X-RateLimit-Usage` headers are not provided
 
+#### Callback interface
+
 ```js
 var strava = require('strava-v3');
 strava.athlete.get({'access_token':'abcde'},function(err,payload,limits) {
@@ -173,6 +175,19 @@ strava.athlete.get({'access_token':'abcde'},function(err,payload,limits) {
     */
 });
 ```
+#### Global status
+
+In our promise API, only the response body "payload" value is returned as a
+[Bluebird promise](https://bluebirdjs.com/docs/api-reference.html). To track
+rate limiting we use a global counter accessible through `strava.rateLimiting`.
+ The rate limiting status is updated with each request.
+
+
+    // returns true if the most recent request exceeded the rate limit
+    strava.rateLimiting.exceeded()
+
+    // returns the current decimal fraction (from 0 to 1) of rate used. The greater of the short and long term limits.
+    strava.rateLimiting.fractionReached();
 
 ### Supported API Endpoints
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var fs = require('fs')
     , segmentEfforts = require('./lib/segmentEfforts')
     , streams = require('./lib/streams')
     , uploads = require('./lib/uploads')
+    , rateLimiting = require('./lib/rateLimiting')
     , runningRaces = require('./lib/runningRaces')
     , routes = require('./lib/routes')
     ;
@@ -32,6 +33,7 @@ strava.segments = segments;
 strava.segmentEfforts = segmentEfforts;
 strava.streams = streams;
 strava.uploads = uploads;
+strava.rateLimiting = rateLimiting;
 strava.runningRaces = runningRaces;
 strava.routes = routes;
 

--- a/lib/activities.js
+++ b/lib/activities.js
@@ -48,14 +48,14 @@ activities.get = function(args,done) {
     }
 
     endpoint += args.id + '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 activities.create = function(args,done) {
 
     var endpoint = 'activities';
 
     args.body = util.getRequestBodyObj(_createAllowedProps,args);
-    util.postEndpoint(endpoint,args,done);
+    return util.postEndpoint(endpoint,args,done);
 };
 activities.update = function(args,done) {
 
@@ -73,7 +73,7 @@ activities.update = function(args,done) {
 
     args.form = form;
 
-    util.putEndpoint(endpoint,args,done);
+    return util.putEndpoint(endpoint,args,done);
 };
 activities.delete = function(args,done) {
 
@@ -87,12 +87,12 @@ activities.delete = function(args,done) {
     }
 
     endpoint += args.id;
-    util.deleteEndpoint(endpoint,args,done);
+    return util.deleteEndpoint(endpoint,args,done);
 };
 activities.listFriends = function(args,done) {
 
     var endpoint = 'activities/following/';
-    _listHelper(endpoint,args,done);
+    return _listHelper(endpoint,args,done);
 };
 activities.listZones = function(args,done) {
 
@@ -107,7 +107,7 @@ activities.listZones = function(args,done) {
 
     endpoint += args.id + '/zones';
 
-    _listHelper(endpoint,args,done);
+    return _listHelper(endpoint,args,done);
 };
 activities.listLaps = function(args,done) {
 
@@ -122,7 +122,7 @@ activities.listLaps = function(args,done) {
 
     endpoint += args.id + '/laps';
 
-    _listHelper(endpoint,args,done);
+    return _listHelper(endpoint,args,done);
 };
 activities.listComments = function(args,done) {
 
@@ -137,7 +137,7 @@ activities.listComments = function(args,done) {
 
     endpoint += args.id + '/comments';
 
-    _listHelper(endpoint,args,done);
+    return _listHelper(endpoint,args,done);
 };
 activities.listKudos = function(args,done) {
 
@@ -152,7 +152,7 @@ activities.listKudos = function(args,done) {
 
     endpoint += args.id + '/kudos';
 
-    _listHelper(endpoint,args,done);
+    return _listHelper(endpoint,args,done);
 };
 activities.listPhotos = function(args,done) {
 
@@ -182,7 +182,7 @@ activities.listPhotos = function(args,done) {
 
     endpoint += '?' + completeQS;
 
-    util.getEndpoint(endpoint, args, done);
+    return util.getEndpoint(endpoint, args, done);
 };
 activities.listRelated = function(args,done) {
 
@@ -196,7 +196,7 @@ activities.listRelated = function(args,done) {
 
     endpoint += args.id + '/related';
 
-    _listHelper(endpoint,args,done);
+    return _listHelper(endpoint,args,done);
 };
 //===== activities endpoint =====
 
@@ -206,7 +206,7 @@ var _listHelper = function(endpoint,args,done) {
     var qs = util.getPaginationQS(args);
 
     endpoint +=  '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== helpers =====
 

--- a/lib/activities.js
+++ b/lib/activities.js
@@ -37,17 +37,11 @@ var activities = {}
 //===== activities endpoint =====
 activities.get = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null
-        , qs = util.getQS(_qsAllowedProps,args);
+    var qs = util.getQS(_qsAllowedProps,args);
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
+    _requireActivityId(args)
 
-    endpoint += args.id + '?' + qs;
+    var endpoint = 'activities/' + args.id + '?' + qs;
     return util.getEndpoint(endpoint,args,done);
 };
 activities.create = function(args,done) {
@@ -59,17 +53,11 @@ activities.create = function(args,done) {
 };
 activities.update = function(args,done) {
 
-    var endpoint = 'activities/'
-        , form = util.getRequestBodyObj(_updateAllowedProps,args)
-        , err = null;
+    var form = util.getRequestBodyObj(_updateAllowedProps,args);
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
+    _requireActivityId(args);
 
-    endpoint += args.id;
+    var endpoint = 'activities/' + args.id;
 
     args.form = form;
 
@@ -77,16 +65,10 @@ activities.update = function(args,done) {
 };
 activities.delete = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args);
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
+    var endpoint = 'activities/' + args.id;
 
-    endpoint += args.id;
     return util.deleteEndpoint(endpoint,args,done);
 };
 activities.listFriends = function(args,done) {
@@ -96,76 +78,41 @@ activities.listFriends = function(args,done) {
 };
 activities.listZones = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args);
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
-
-    endpoint += args.id + '/zones';
+    var endpoint = 'activities/' + args.id + '/zones';
 
     return _listHelper(endpoint,args,done);
 };
 activities.listLaps = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args);
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
-
-    endpoint += args.id + '/laps';
+    var endpoint = 'activities/' + args.id + '/laps';
 
     return _listHelper(endpoint,args,done);
 };
 activities.listComments = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args);
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
-
-    endpoint += args.id + '/comments';
+    var endpoint = 'activities/'+ args.id + '/comments';
 
     return _listHelper(endpoint,args,done);
 };
 activities.listKudos = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args)
 
-    //require activity id
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
-
-    endpoint += args.id + '/kudos';
+    var endpoint = 'activities/' + args.id + '/kudos';
 
     return _listHelper(endpoint,args,done);
 };
 activities.listPhotos = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args);
 
-    //require activity id
-    if (typeof args.id === 'undefined') {
-        err = { msg: 'args must include an activity id' };
-        return done(err);
-    }
-
-    endpoint += args.id + '/photos';
+    endpoint = 'activities/' + args.id + '/photos';
 
     var pageQS = util.getPaginationQS(args);
 
@@ -186,21 +133,21 @@ activities.listPhotos = function(args,done) {
 };
 activities.listRelated = function(args,done) {
 
-    var endpoint = 'activities/'
-        , err = null;
+    _requireActivityId(args);
 
-    if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
-    }
-
-    endpoint += args.id + '/related';
+    endpoint = 'activities/' + args.id + '/related';
 
     return _listHelper(endpoint,args,done);
 };
 //===== activities endpoint =====
 
 //===== helpers =====
+var _requireActivityId = function(args) {
+    if (typeof args.id === 'undefined') {
+        throw new Error('args must include an activity id')
+    }
+}
+
 var _listHelper = function(endpoint,args,done) {
 
     var qs = util.getPaginationQS(args);

--- a/lib/athlete.js
+++ b/lib/athlete.js
@@ -27,31 +27,31 @@ var athlete = {}
 athlete.get = function(args,done) {
 
     var endpoint = 'athlete';
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 athlete.listFriends = function(args,done) {
 
-    _listHelper('friends',args,done);
+    return _listHelper('friends',args,done);
 };
 athlete.listFollowers = function(args,done) {
 
-    _listHelper('followers',args,done);
+    return _listHelper('followers',args,done);
 };
 athlete.listActivities = function(args,done) {
 
-    _listHelper('activities',args,done);
+    return _listHelper('activities',args,done);
 };
 athlete.listClubs = function(args,done) {
 
-    _listHelper('clubs',args,done);
+    return _listHelper('clubs',args,done);
 };
 athlete.listRoutes = function(args,done) {
 
-    _listHelper('routes',args,done);
+    return _listHelper('routes',args,done);
 };
 athlete.listZones = function(args,done) {
 
-    _listHelper('zones',args,done);
+    return _listHelper('zones',args,done);
 };
 
 athlete.update = function(args,done) {
@@ -60,7 +60,7 @@ athlete.update = function(args,done) {
         , form = util.getRequestBodyObj(_updateAllowedProps,args);
 
     args.form = form;
-    util.putEndpoint(endpoint,args,done);
+    return util.putEndpoint(endpoint,args,done);
 };
 //===== athlete endpoint =====
 
@@ -71,7 +71,7 @@ var _listHelper = function(listType,args,done) {
         , qs = util.getQS(_qsAllowedProps,args);
 
     endpoint += listType + '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== helpers =====
 

--- a/lib/athletes.js
+++ b/lib/athletes.js
@@ -10,23 +10,23 @@ var athletes = {};
 //===== athletes endpoint =====
 athletes.get = function(args,done) {
 
-    _listHelper('',args,done);
+    return _listHelper('',args,done);
 };
 athletes.listFriends = function(args,done) {
 
-    _listHelper('friends',args,done);
+    return _listHelper('friends',args,done);
 };
 athletes.listFollowers = function(args,done) {
 
-    _listHelper('followers',args,done);
+    return _listHelper('followers',args,done);
 };
 athletes.stats = function(args, done) {
 
-    _listHelper('stats',args,done);
+    return _listHelper('stats',args,done);
 };
 athletes.listKoms = function(args,done) {
 
-    _listHelper('koms',args,done);
+    return _listHelper('koms',args,done);
 };
 //===== athletes endpoint =====
 
@@ -44,7 +44,7 @@ var _listHelper = function(listType,args,done) {
     }
 
     endpoint += args.id + '/' + listType + '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== helpers =====
 

--- a/lib/athletes.js
+++ b/lib/athletes.js
@@ -39,8 +39,7 @@ var _listHelper = function(listType,args,done) {
 
     //require athlete id
     if(typeof args.id === 'undefined') {
-        err = {'msg':'args must include an athlete id'};
-        return done(err);
+        throw new Error('args must include an athlete id');
     }
 
     endpoint += args.id + '/' + listType + '?' + qs;

--- a/lib/clubs.js
+++ b/lib/clubs.js
@@ -18,35 +18,35 @@ clubs.get = function(args,done) {
     }
 
     endpoint += args.id;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 clubs.listMembers = function(args,done) {
 
-    _listHelper('members',args,done);
+    return _listHelper('members',args,done);
 };
 clubs.listActivities = function(args,done) {
 
-    _listHelper('activities',args,done);
+    return _listHelper('activities',args,done);
 };
 clubs.listAnnouncements = function(args,done) {
 
-    _listHelper('announcements',args,done);
+    return _listHelper('announcements',args,done);
 };
 clubs.listEvents = function(args,done) {
 
-    _listHelper('group_events',args,done);
+    return _listHelper('group_events',args,done);
 };
 clubs.listAdmins = function(args,done) {
 
-    _listHelper('admins',args,done);
+    return _listHelper('admins',args,done);
 };
 clubs.joinClub = function(args,done) {
 
-    _listHelper('join',args,done);
+    return _listHelper('join',args,done);
 };
 clubs.leaveClub = function(args,done) {
 
-    _listHelper('leave',args,done);
+    return _listHelper('leave',args,done);
 };
 //===== clubs endpoint =====
 
@@ -65,7 +65,7 @@ var _listHelper = function(listType,args,done) {
 
     endpoint += args.id + '/' + listType + '?' + qs;
 
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== helpers =====
 

--- a/lib/gear.js
+++ b/lib/gear.js
@@ -17,7 +17,7 @@ gear.get = function(args,done) {
     }
 
     endpoint += args.id;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 
 module.exports = gear;

--- a/lib/gear.js
+++ b/lib/gear.js
@@ -12,8 +12,7 @@ gear.get = function(args,done) {
 
     //require gear id
     if(typeof args.id === 'undefined') {
-        err = {msg:'args must include a gear id'};
-        return done(err);
+        throw new Error('args must include a gear id');
     }
 
     endpoint += args.id;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -4,7 +4,8 @@
 
 var util = require('./util')
     , authenticator = require('./authenticator')
-    , request = require('request')
+    , Promise = require('bluebird')
+    , request = require('request-promise')
     , querystring = require('querystring');
 
 var oauth = {};
@@ -42,7 +43,7 @@ oauth.getToken = function(code,done) {
         };
 
     args.form = form;
-    util.postEndpoint(endpoint,args,done);
+    return util.postEndpoint(endpoint,args,done);
 };
 
 oauth.deauthorize = function(args,done) {
@@ -54,23 +55,22 @@ oauth.deauthorize = function(args,done) {
             url: url
             , method: 'POST'
             , json: true
+              // We want to consider some 30x responses valid as well
+              // 'simple' would only consider 2xx responses successful
+            , simple: false
             , headers: {
                 Authorization: 'Bearer ' + args.access_token
             }
         };
 
-    request(options, function (err, response, payload) {
-
-        if (!err) {
-            //console.log(payload);
-        }
-        else {
-            console.log('api call error');
-            console.log(err);
-        }
-
-        done(err, payload);
-    });
+    // Promise.resolve is used to convert the promise returned to a Bluebird promise
+    // tapCatch is used to log errors without stopping the promise flow.
+    // asCallback is used to support both Promise and callback-based APIs
+    return Promise.resolve(request(options)).
+        tapCatch(function(err) {
+          console.log('api call error');
+          console.log(err);
+        }).asCallback(done)
 };
 
 module.exports = oauth;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -63,14 +63,15 @@ oauth.deauthorize = function(args,done) {
             }
         };
 
-    // Promise.resolve is used to convert the promise returned to a Bluebird promise
+    // Promise.resolve is used to convert the promise returned
+    // to a Bluebird promise
     // tapCatch is used to log errors without stopping the promise flow.
     // asCallback is used to support both Promise and callback-based APIs
     return Promise.resolve(request(options)).
         tapCatch(function(err) {
           console.log('api call error');
           console.log(err);
-        }).asCallback(done)
+        }).asCallback(done);
 };
 
 module.exports = oauth;

--- a/lib/rateLimiting.js
+++ b/lib/rateLimiting.js
@@ -1,0 +1,81 @@
+
+var RateLimit = {
+  requestTime : new Date(), // Date
+  shortTermLimit  : 0, // Int
+  longTermLimit   : 0, // Int
+  shortTermUsage  : 0, // Int
+  longTermUsage   : 0, // Init
+};
+var rl = RateLimit;
+
+
+// should be called as `strava.rateLimiting.exceeded() to determine if the most recent request exceeded the rate limit
+RateLimit.exceeded = function () {
+  if (rl.shortTermUsage >= rl.shortTermLimit) {
+    return true
+  }
+
+  if (rl.longTermUsage >= rl.longTermLimit) {
+    return true
+  }
+
+  return false
+}
+
+// fractionReached returns the current faction of rate used. The greater of the short and long term limits.
+// Should be called as `strava.fateLimiting.fractionReached()`
+RateLimit.fractionReached = function () {
+  var shortLimitFraction = rl.shortTermUsage / rl.shortTermLimit;
+  var longLimitFraction = rl.longTermUsage / rl.longTermLimit;
+
+  if (shortLimitFraction > longLimitFraction) {
+    return shortLimitFraction
+  } 
+  else {
+    return longLimitFraction
+  }
+
+}
+
+RateLimit.parseRateLimits = function (headers) {
+    if(!headers['x-ratelimit-limit'] || !headers['x-ratelimit-usage']) {
+        return null;
+    }
+
+    var limit = headers['x-ratelimit-limit'].split(',')
+        , usage = headers['x-ratelimit-usage'].split(',')
+        , radix = 10;
+
+    return {
+        shortTermUsage: parseInt(usage[0], radix),
+        shortTermLimit: parseInt(limit[0], radix),
+        longTermUsage: parseInt(usage[1], radix),
+        longTermLimit: parseInt(limit[1], radix)
+    };
+
+}
+
+RateLimit.updateRateLimits = function (headers) {
+  var newLimits = this.parseRateLimits(headers);
+  if (newLimits) {
+    this.requestDate = new Date();
+    this.shortTermLimit = !isNaN(newLimits.shortTermLimit) ? newLimits.shortTermLimit : 0;
+    this.shortTermUsage = !isNaN(newLimits.shortTermUsage) ? newLimits.shortTermUsage : 0;
+    this.longTermLimit = !isNaN(newLimits.longTermLimit) ? newLimits.longTermLimit : 0;
+    this.longTermUsage = !isNaN(newLimits.longTermUsage) ? newLimits.longTermUsage : 0;
+  }
+  else {
+    this.clear()
+  }
+  return newLimits;
+}
+
+RateLimit.clear = function () {
+  this.requestTime = new Date();
+  this.shortTermLimit = 0;
+  this.longTermLimit = 0;
+  this.shortTermUsage = 0;
+  this.longTermUsage = 0;
+}
+
+module.exports = RateLimit

--- a/lib/rateLimiting.js
+++ b/lib/rateLimiting.js
@@ -9,33 +9,35 @@ var RateLimit = {
 var rl = RateLimit;
 
 
-// should be called as `strava.rateLimiting.exceeded() to determine if the most recent request exceeded the rate limit
+// should be called as `strava.rateLimiting.exceeded()
+// to determine if the most recent request exceeded the rate limit
 RateLimit.exceeded = function () {
   if (rl.shortTermUsage >= rl.shortTermLimit) {
-    return true
+    return true;
   }
 
   if (rl.longTermUsage >= rl.longTermLimit) {
-    return true
+    return true;
   }
 
-  return false
-}
+  return false;
+};
 
-// fractionReached returns the current fraction of rate used. The greater of the short and long term limits.
+// fractionReached returns the current fraction of rate used.
+// The greater of the short and long term limits.
 // Should be called as `strava.rateLimiting.fractionReached()`
 RateLimit.fractionReached = function () {
   var shortLimitFraction = rl.shortTermUsage / rl.shortTermLimit;
   var longLimitFraction = rl.longTermUsage / rl.longTermLimit;
 
   if (shortLimitFraction > longLimitFraction) {
-    return shortLimitFraction
+    return shortLimitFraction;
   } 
   else {
-    return longLimitFraction
+    return longLimitFraction;
   }
 
-}
+};
 
 RateLimit.parseRateLimits = function (headers) {
     if(!headers['x-ratelimit-limit'] || !headers['x-ratelimit-usage']) {
@@ -53,22 +55,26 @@ RateLimit.parseRateLimits = function (headers) {
         longTermLimit: parseInt(limit[1], radix)
     };
 
-}
+};
 
 RateLimit.updateRateLimits = function (headers) {
   var newLimits = this.parseRateLimits(headers);
   if (newLimits) {
     this.requestDate = new Date();
-    this.shortTermLimit = !isNaN(newLimits.shortTermLimit) ? newLimits.shortTermLimit : 0;
-    this.shortTermUsage = !isNaN(newLimits.shortTermUsage) ? newLimits.shortTermUsage : 0;
-    this.longTermLimit = !isNaN(newLimits.longTermLimit) ? newLimits.longTermLimit : 0;
-    this.longTermUsage = !isNaN(newLimits.longTermUsage) ? newLimits.longTermUsage : 0;
+    this.shortTermLimit =
+      !isNaN(newLimits.shortTermLimit) ? newLimits.shortTermLimit : 0;
+    this.shortTermUsage =
+      !isNaN(newLimits.shortTermUsage) ? newLimits.shortTermUsage : 0;
+    this.longTermLimit =
+      !isNaN(newLimits.longTermLimit) ? newLimits.longTermLimit : 0;
+    this.longTermUsage =
+      !isNaN(newLimits.longTermUsage) ? newLimits.longTermUsage : 0;
   }
   else {
-    this.clear()
+    this.clear();
   }
   return newLimits;
-}
+};
 
 RateLimit.clear = function () {
   this.requestTime = new Date();
@@ -76,6 +82,6 @@ RateLimit.clear = function () {
   this.longTermLimit = 0;
   this.shortTermUsage = 0;
   this.longTermUsage = 0;
-}
+};
 
-module.exports = RateLimit
+module.exports = RateLimit;

--- a/lib/rateLimiting.js
+++ b/lib/rateLimiting.js
@@ -22,8 +22,8 @@ RateLimit.exceeded = function () {
   return false
 }
 
-// fractionReached returns the current faction of rate used. The greater of the short and long term limits.
-// Should be called as `strava.fateLimiting.fractionReached()`
+// fractionReached returns the current fraction of rate used. The greater of the short and long term limits.
+// Should be called as `strava.rateLimiting.fractionReached()`
 RateLimit.fractionReached = function () {
   var shortLimitFraction = rl.shortTermUsage / rl.shortTermLimit;
   var longLimitFraction = rl.longTermUsage / rl.longTermLimit;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -22,7 +22,7 @@ routes.get = function(args,done) {
     }
 
     endpoint += args.id + '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== routes endpoint =====
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -17,8 +17,7 @@ routes.get = function(args,done) {
 
     //require route id
     if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an route id'};
-        return done(err);
+        throw new Error('args must include an route id');
     }
 
     endpoint += args.id + '?' + qs;

--- a/lib/runningRaces.js
+++ b/lib/runningRaces.js
@@ -21,14 +21,14 @@ runningRaces.get = function(args,done) {
     }
 
     endpoint += args.id;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 
 runningRaces.listRaces = function(args,done) {
     var qs = util.getQS(_qsAllowedProps,args)
         , endpoint = 'running_races?' + qs;
 
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 
 //===== running_races endpoint =====

--- a/lib/runningRaces.js
+++ b/lib/runningRaces.js
@@ -16,8 +16,7 @@ runningRaces.get = function(args,done) {
 
     //require running race id
     if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an race id'};
-        return done(err);
+        throw new Error('args must include an race id');
     }
 
     endpoint += args.id;

--- a/lib/segmentEfforts.js
+++ b/lib/segmentEfforts.js
@@ -20,7 +20,7 @@ segmentEfforts.get = function(args,done) {
     }
 
     endpoint += args.id;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== segment_efforts endpoint =====
 

--- a/lib/segmentEfforts.js
+++ b/lib/segmentEfforts.js
@@ -15,8 +15,7 @@ segmentEfforts.get = function(args,done) {
 
     //require segment id
     if(typeof args.id === 'undefined') {
-        err = {msg:'args must include a segment id'};
-        return done(err);
+        throw new Error('args must include a segment id');
     }
 
     endpoint += args.id;

--- a/lib/segments.js
+++ b/lib/segments.js
@@ -47,7 +47,7 @@ segments.get = function(args,done) {
     }
 
     endpoint += args.id;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 
 segments.listStarred = function(args,done) {
@@ -55,7 +55,7 @@ segments.listStarred = function(args,done) {
     var qs = util.getQS(_qsAllowedProps,args)
         , endpoint = 'segments/starred?' + qs;
 
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 
 segments.starSegment = function(args,done) {
@@ -77,12 +77,12 @@ segments.starSegment = function(args,done) {
 
 segments.listEfforts = function(args,done) {
 
-    _listHelper('all_efforts',args,done);
+    return _listHelper('all_efforts',args,done);
 };
 
 segments.listLeaderboard = function(args,done) {
 
-    _listHelper('leaderboard',args,done);
+    return _listHelper('leaderboard',args,done);
 };
 
 segments.explore = function(args,done) {
@@ -90,7 +90,7 @@ segments.explore = function(args,done) {
     var qs = util.getQS(_qsAllowedProps,args)
         , endpoint = 'segments/explore?' + qs;
 
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== segments endpoint =====
 
@@ -108,7 +108,7 @@ var _listHelper = function(listType,args,done) {
     }
 
     endpoint += args.id + '/' + listType + '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== helpers =====
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -54,7 +54,7 @@ var _typeHelper = function(endpoint,args,done) {
     }
 
     endpoint += '/' + args.id + '/streams/' + args.types + '?' + qs;
-    util.getEndpoint(endpoint,args,done);
+    return util.getEndpoint(endpoint,args,done);
 };
 //===== helpers =====
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -44,13 +44,11 @@ var _typeHelper = function(endpoint,args,done) {
 
     //require id
     if(typeof args.id === 'undefined') {
-        err = {'msg':'args must include an id'};
-        return done(err);
+        throw new Error('args must include an id');
     }
     //require types
     if(typeof args.types === 'undefined') {
-        err = {'msg':'args must include types'};
-        return done(err);
+        throw new Error('args must include types');
     }
 
     endpoint += '/' + args.id + '/streams/' + args.types + '?' + qs;

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -35,7 +35,7 @@ uploads.post = function(args,done) {
             args.formData[_allowedFormProps[i]] = args[_allowedFormProps[i]];
     }
 
-    util.postUpload(args,function(err,payload) {
+    return util.postUpload(args,function(err,payload) {
 
         // finish off this branch of the call and let the
         // status checking bit happen after
@@ -47,7 +47,7 @@ uploads.post = function(args,done) {
               id: payload.id,
               access_token: args.access_token
             };
-            self._check(checkArgs,args.statusCallback);
+            return self._check(checkArgs,args.statusCallback);
         }
 
     });
@@ -59,7 +59,7 @@ uploads._check = function(args,cb) {
         , self = this;
 
     endpoint += '/' + args.id;
-    util.getEndpoint(endpoint,args,function(err,payload) {
+    return util.getEndpoint(endpoint,args,function(err,payload) {
 
         if(!err) {
             cb(err,payload);

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -24,8 +24,7 @@ uploads.post = function(args,done) {
         typeof args.file === 'undefined' || typeof args.data_type == 'undefined'
         ) {
 
-        err = {'msg':'args must include both file and data_type'};
-        return done(err);
+        throw new Error('args must include both file and data_type');
     }
 
     //setup formData for request

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,16 +2,16 @@
  * Created by austin on 9/18/14.
  */
 
-var request = require('request')
+var request = require('request-promise')
+    , Promise = require('bluebird')
     , querystring = require('querystring')
     , fs = require('fs')
-    , authenticator = require('./authenticator');
+    , authenticator = require('./authenticator')
+    , rateLimiting = require('./rateLimiting');
 
 //request.debug = true
 
 var util = {};
-util.rateLimit = 'x-ratelimit-limit';
-util.rateUsage = 'x-ratelimit-usage';
 util.endpointBase = 'https://www.strava.com/api/v3/';
 
 //===== generic GET =====
@@ -33,7 +33,7 @@ util.getEndpoint = function(endpoint,args,done) {
             }
         };
 
-    _requestHelper(options,done);
+    return _requestHelper(options,done);
 };
 
 //===== generic PUT =====
@@ -64,7 +64,7 @@ util.putEndpoint = function(endpoint,args,done) {
     if(args.form)
         options.form = args.form;
 
-    _requestHelper(options,done);
+    return _requestHelper(options,done);
 };
 
 //===== generic POST =====
@@ -99,7 +99,7 @@ util.postEndpoint = function(endpoint,args,done) {
     if(args.multipart)
         options.multipart = args.multipart;
 
-    _requestHelper(options,done);
+    return _requestHelper(options,done);
 };
 
 //===== generic DELETE =====
@@ -126,7 +126,7 @@ util.deleteEndpoint = function(endpoint,args,done) {
             }
         };
 
-    _requestHelper(options,done);
+    return _requestHelper(options,done);
 };
 
 //===== postUpload =====
@@ -210,33 +210,41 @@ util.getRequestBodyObj = function(allowedProps,args) {
 
 //===== helpers =====
 var _requestHelper = function(options,done) {
+    // We need the full response so we can get at the headers
+    options.resolveWithFullResponse = true;
 
-    request(options, function (err, response, payload) {
-        if (err) {
-            console.log('api call error');
-            console.log(err);
+    // We want to consider some 30x responses valid as well
+    // 'simple' would only consider 2xx responses successful
+    options.simple = false;
+
+    var limits;
+
+    var callback;
+
+    // For asCallback to work properly, a function should only be passed to it
+    //  if the caller provided one
+    if (done) { 
+        callback = function (err, payload) {
+           done(err,payload,limits)
         }
-
-        done(err, payload, parseRateLimits(response.headers));
-    });
-};
-
-function parseRateLimits(headers) {
-    if(!headers[util.rateLimit] || !headers[util.rateUsage]) {
-        return null;
     }
 
-    var limit = headers[util.rateLimit].split(',')
-        , usage = headers[util.rateUsage].split(',')
-        , radix = 10;
+    // Promise.resolve is used to convert the promise returned to a Bluebird promise
+    // tapCatch is used to log errors without stopping the promise flow.
+    // asCallback is used to support both Promise and callback-based APIs
+    return Promise.resolve(request(options)).
+        tapCatch(function(err) {
+          console.log('api call error');
+          console.log(err);
+        }).
+        then(function (response) {
+          // The old callback API returns returns the current limits as an extra arg in the callback
+          // The newer promise-bsed API updates a global rateLimiting counter
+          limits = rateLimiting.updateRateLimits(response.headers);
+          return Promise.resolve(response.body)
+        }).asCallback(callback);
+};
 
-    return {
-        shortTermUsage: parseInt(usage[0], radix),
-        shortTermLimit: parseInt(limit[0], radix),
-        longTermUsage: parseInt(usage[1], radix),
-        longTermLimit: parseInt(limit[1], radix)
-    };
-}
 //===== helpers =====
 
 module.exports = util;

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,7 @@ util.getEndpoint = function(endpoint,args,done) {
     }
 
     var token = args.access_token || authenticator.getToken();
-    if(!token) return done({msg: 'you must include an access_token'});
+    if(!token) return done(new Error('you must include an access_token'));
 
     var url = this.endpointBase + endpoint
         , options = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -223,13 +223,14 @@ var _requestHelper = function(options,done) {
 
     // For asCallback to work properly, a function should only be passed to it
     //  if the caller provided one
-    if (done) { 
+    if (done) {
         callback = function (err, payload) {
-           done(err,payload,limits)
-        }
+           done(err,payload,limits);
+        };
     }
 
-    // Promise.resolve is used to convert the promise returned to a Bluebird promise
+    // Promise.resolve is used to convert the promise returned
+    //  to a Bluebird promise
     // tapCatch is used to log errors without stopping the promise flow.
     // asCallback is used to support both Promise and callback-based APIs
     return Promise.resolve(request(options)).
@@ -238,10 +239,11 @@ var _requestHelper = function(options,done) {
           console.log(err);
         }).
         then(function (response) {
-          // The old callback API returns returns the current limits as an extra arg in the callback
+          // The old callback API returns returns the current limits
+          //  as an extra arg in the callback
           // The newer promise-bsed API updates a global rateLimiting counter
           limits = rateLimiting.updateRateLimits(response.headers);
-          return Promise.resolve(response.body)
+          return Promise.resolve(response.body);
         }).asCallback(callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-simple-mocha": "^0.4.1",
+    "lodash": "^4.17.4",
     "mocha": "^3.3.0",
     "mock-fs": "^4.3.0",
     "should": "^4.6.5",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-simple-mocha": "^0.4.1",
-    "mocha": "^1.21.5",
-    "mock-fs": "^3.9.0",
+    "mocha": "^3.3.0",
+    "mock-fs": "^4.3.0",
     "should": "^4.6.5",
     "sinon": "^1.17.4"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "request": "^2.64.0"
   },
   "devDependencies": {
+    "env-restorer": "^1.0.0",
     "es6-promise": "^3.2.1",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "homepage": "https://github.com/unboundev/node-strava-v3",
   "dependencies": {
-    "request": "^2.64.0"
+    "bluebird": "^3.5.0",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.0"
   },
   "devDependencies": {
     "env-restorer": "^1.0.0",

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -4,6 +4,7 @@
 
 var fs = require('fs');
 var strava = require('../');
+var _ = require('lodash');
 
 var testsHelper = {};
 
@@ -13,15 +14,30 @@ testsHelper.getSampleAthlete = function(done) {
 
 testsHelper.getSampleActivity = function(done) {
     strava.athlete.listActivities({include_all_efforts:true},function(err,payload) {
-        strava.activities.get({id:payload[0].id,include_all_efforts:true},function(err,payload) {
+        if (err)
+          return done(err)
 
-            done(err,payload);
-        });
+        if (!payload.length)
+          return done(new Error("Must have at least one activity posted to Strava to test with."));
+
+        // If we find an activity with an achievement, there's a better chance that it contains a segment.
+        // This is necessary for getSampleSegment, which uses this function.
+        var withSegment = _.filter(payload, function(a) { return a.achievement_count > 1 })[0];
+
+        if (!withSegment)
+          return done(new Error("Must have at least one activity posted to Strava with a segment effort to test with."));
+
+        strava.activities.get({id:withSegment.id,include_all_efforts:true},done)
     });
 };
 
 testsHelper.getSampleClub = function(done) {
     strava.athlete.listClubs({},function(err,payload) {
+        if (err)
+          return done(err)
+
+        if (!payload.length)
+          return done(new Error("Must have joined at least one club on Strava to test with."));
 
         done(err,payload[0]);
     });
@@ -29,14 +45,34 @@ testsHelper.getSampleClub = function(done) {
 
 testsHelper.getSampleRoute = function(done) {
     strava.athlete.listRoutes({},function(err,payload) {
+        if (err)
+          return done(err)
+
+        if (!payload.length)
+          return done(new Error("Must have created at least one route on Strava to test with."));
+
         done(err,payload[0]);
     });
 };
 
 testsHelper.getSampleGear = function(done) {
     this.getSampleAthlete(function(err,payload) {
+        if (err)
+          return done(err)
 
-        var gear = payload.bikes.length ? payload.bikes[0] : payload.shoes[0];
+        var gear;
+
+        if (payload.bikes && payload.bikes.length) {
+          gear = payload.bikes[0];
+        }
+        else if (payload.shoes) {
+          gear = payload.shoes[0];
+        }
+        else {
+          return done(new Error("Must post at least one bike or shoes to Strava to test with"))
+        }
+
+
         done(err,gear);
     });
 };
@@ -44,6 +80,11 @@ testsHelper.getSampleGear = function(done) {
 testsHelper.getSampleSegmentEffort = function(done) {
 
     this.getSampleActivity(function(err,payload) {
+        if (err)
+          return done(err);
+
+        if (!payload.segment_efforts.length)
+          return done(new Error("Must have at least one segment effort posted to Strava to test with."));
 
         done(err,payload.segment_efforts[0]);
     });
@@ -52,6 +93,8 @@ testsHelper.getSampleSegmentEffort = function(done) {
 testsHelper.getSampleSegment = function(done) {
 
     this.getSampleSegmentEffort(function(err,payload) {
+        if (err)
+          return done(err);
 
         done(err,payload.segment);
     });

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -27,7 +27,7 @@ testsHelper.getSampleActivity = function(done) {
         if (!withSegment)
           return done(new Error("Must have at least one activity posted to Strava with a segment effort to test with."));
 
-        strava.activities.get({id:withSegment.id,include_all_efforts:true},done)
+        return strava.activities.get({id:withSegment.id,include_all_efforts:true},done)
     });
 };
 

--- a/test/activities.js
+++ b/test/activities.js
@@ -72,6 +72,13 @@ describe('activities_test', function() {
             });
         });
 
+        it('should return information about the corresponding activity (Promise API)', function() {
+            return strava.activities.get({id: testActivity.id}).
+                then(function(payload) {
+                    (payload.resource_state).should.be.exactly(3);
+                });
+        });
+
         it('should work with a specified access token', function(done) {
             var token = testHelper.getAccessToken();
             var tokenStub = sinon.stub(authenticator, 'getToken', function () {

--- a/test/activities.js
+++ b/test/activities.js
@@ -17,6 +17,8 @@ describe('activities_test', function() {
     before(function(done) {
 
         testHelper.getSampleActivity(function(err,sampleActivity) {
+            if (err)
+              return done(err)
 
             _sampleActivity = sampleActivity;
             _sampleActivityPreEdit = sampleActivity;

--- a/test/athlete.js
+++ b/test/athlete.js
@@ -29,6 +29,8 @@ describe('athlete_test', function(){
         it('should return information about friends associated to athlete with access_token', function(done) {
 
             strava.athlete.listFriends({},function(err,payload){
+                if (err)
+                  return done(err)
 
                 if(!err) {
                     //console.log(payload);

--- a/test/authenticator.js
+++ b/test/authenticator.js
@@ -1,8 +1,16 @@
 
 var should = require('should')
     , mockFS = require('mock-fs')
+    , envRestorer = require( 'env-restorer' )
     , authenticator = require('../lib/authenticator');
     var testHelper = require('./_helper')
+
+// Restore File system mocks, authentication state and environment variables
+var restoreAll = function () {
+  mockFS.restore();
+  authenticator.purge();
+  envRestorer.restore();
+}
 
 describe('authenticator_test', function() {
     describe('#getToken()', function() {
@@ -15,31 +23,23 @@ describe('authenticator_test', function() {
                     'redirect_uri': 'https://sample.com'
                 })
             });
-            var originalToken = process.env.STRAVA_ACCESS_TOKEN;
             delete process.env.STRAVA_ACCESS_TOKEN;
             authenticator.purge();
 
             (authenticator.getToken()).should.be.exactly('abcdefghi');
-
-            mockFS.restore();
-            process.env.STRAVA_ACCESS_TOKEN = originalToken;
-            authenticator.purge();
         });
 
         it('should read the access token from the env vars', function() {
             mockFS({
                 'data': {}
             });
-            var originalToken = process.env.STRAVA_ACCESS_TOKEN;
             process.env.STRAVA_ACCESS_TOKEN = 'abcdefghi';
             authenticator.purge();
 
             (authenticator.getToken()).should.be.exactly('abcdefghi');
-
-            mockFS.restore();
-            process.env.STRAVA_ACCESS_TOKEN = originalToken;
-            authenticator.purge();
         });
+
+        afterEach(restoreAll)
     });
 
     describe('#getClientId()', function() {
@@ -52,31 +52,23 @@ describe('authenticator_test', function() {
                     'redirect_uri': 'https://sample.com'
                 })
             });
-            var originalClientId = process.env.STRAVA_CLIENT_ID;
             delete process.env.STRAVA_CLIENT_ID;
             authenticator.purge();
 
             (authenticator.getClientId()).should.be.exactly('jklmnopqr');
-
-            mockFS.restore();
-            process.env.STRAVA_CLIENT_ID = originalClientId
-            authenticator.purge();
         });
 
         it('should read the client id from the env vars', function() {
             mockFS({
                 'data': {}
             });
-            var originalClientId = process.env.STRAVA_CLIENT_ID;
             process.env.STRAVA_CLIENT_ID = 'abcdefghi';
             authenticator.purge();
 
             (authenticator.getClientId()).should.be.exactly('abcdefghi');
-
-            mockFS.restore();
-            process.env.STRAVA_CLIENT_ID = originalClientId;
-            authenticator.purge();
         });
+
+        afterEach(restoreAll)
     });
 
     describe('#getClientSecret()', function() {
@@ -89,31 +81,22 @@ describe('authenticator_test', function() {
                     'redirect_uri': 'https://sample.com'
                 })
             });
-            var originalClientSecret = process.env.STRAVA_CLIENT_SECRET;
             delete process.env.STRAVA_CLIENT_SECRET;
             authenticator.purge();
 
             (authenticator.getClientSecret()).should.be.exactly('stuvwxyz');
-
-            mockFS.restore();
-            process.env.STRAVA_CLIENT_SECRET = originalClientSecret;
-            authenticator.purge();
         });
 
         it('should read the client secret from the env vars', function() {
             mockFS({
                 'data': {}
             });
-            var originalClientSecret = process.env.STRAVA_CLIENT_SECRET;
             process.env.STRAVA_CLIENT_SECRET = 'abcdefghi';
             authenticator.purge();
 
             (authenticator.getClientSecret()).should.be.exactly('abcdefghi');
-
-            mockFS.restore();
-            process.env.STRAVA_CLIENT_SECRET = originalClientSecret;
-            authenticator.purge();
         });
+        afterEach(restoreAll)
     });
 
     describe('#getRedirectUri()', function() {
@@ -126,30 +109,23 @@ describe('authenticator_test', function() {
                     'redirect_uri': 'https://sample.com'
                 })
             });
-            var originalRedirectUri = process.env.STRAVA_REDIRECT_URI;
             delete process.env.STRAVA_REDIRECT_URI;
             authenticator.purge();
 
             (authenticator.getRedirectUri()).should.be.exactly('https://sample.com');
-
-            mockFS.restore();
-            process.env.STRAVA_REDIRECT_URI = originalRedirectUri;
-            authenticator.purge();
         });
 
         it('should read the redirect URI from the env vars', function() {
             mockFS({
                 'data': {}
             });
-            var originalRedirectUri = process.env.STRAVA_REDIRECT_URI;
             process.env.STRAVA_REDIRECT_URI = 'https://sample.com';
             authenticator.purge();
 
             (authenticator.getRedirectUri()).should.be.exactly('https://sample.com');
-
-            mockFS.restore();
-            process.env.STRAVA_REDIRECT_URI = originalRedirectUri;
-            authenticator.purge();
         });
+
+        afterEach(restoreAll)
     });
+
 });

--- a/test/clubs.js
+++ b/test/clubs.js
@@ -13,6 +13,8 @@ describe('clubs_test', function() {
     before(function(done) {
 
         testHelper.getSampleClub(function(err,payload) {
+          if (err)
+            return done(err)
 
             _sampleClub = payload;
             done();

--- a/test/gear.js
+++ b/test/gear.js
@@ -10,8 +10,14 @@ describe('gear_test', function() {
     before(function(done) {
 
         testHelper.getSampleGear(function(err,payload) {
+             if (err)
+               return done(err)
 
             _sampleGear = payload;
+
+            if (!_sampleGear || !_sampleGear.id)
+              return done(new Error("At least one piece of gear posted to Strava is required for testing."))
+
             done();
         });
     });
@@ -21,6 +27,8 @@ describe('gear_test', function() {
         it('should return detailed athlete information about gear (level 3)', function (done) {
 
             strava.gear.get({id:_sampleGear.id}, function (err, payload) {
+                if (err)
+                  return done(err)
 
                 if (!err) {
                     //console.log(payload);

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -30,6 +30,27 @@ describe('oauth_test', function() {
         });
     });
 
+    describe('#deauthorize()', function () {
+        it("Should have method deauthorize", function () {
+           strava.oauth.should.have.property('deauthorize')
+        });
+
+        it("Should return 401 with invalid token", function (done) {
+          strava.oauth.deauthorize({ access_token: 'BOOM'}, function (err, payload) {
+            (payload).should.have.property('message').eql('Authorization Error')
+            done();
+          });
+        });
+
+        it("Should return 401 with invalid token (Promise API)", function () {
+          return strava.oauth.deauthorize({ access_token: 'BOOM'}).
+              then(function (payload) {
+                (payload).should.have.property('message').eql('Authorization Error')
+              });
+        });
+        // Not sure how to test since we don't have a token that we want to deauthorize
+    })
+
     // TODO: Figure out a way to get a valid oAuth code for the token exchange
     describe.skip('#getToken()', function () {
         it('should return an access_token', function (done) {

--- a/test/rateLimiting.js
+++ b/test/rateLimiting.js
@@ -1,0 +1,85 @@
+
+var should = require('should');
+var rateLimiting = require('../lib/rateLimiting');
+
+describe('rateLimiting_test', function () {
+  describe('#fractionReached', function () {
+
+    it("should update requestTime", function () {
+        var before = rateLimiting.requestTime;
+        var headers = {
+          "date": "Tue, 10 Oct 2013 20:11:05 GMT",
+          "x-ratelimit-limit": "600,30000",
+          "x-ratelimit-usage": "300,10000"
+         };
+        rateLimiting.updateRateLimits(headers)
+
+        before.should.not.not.eql(rateLimiting.requestTime)
+    });
+
+    it("should calculate rate limit correctly", function () {
+      (rateLimiting.fractionReached()).should.eql(0.5);
+    });
+
+
+    it("should calculate rate limit correctly", function () {
+        var headers = {
+          "x-ratelimit-limit": "600,30000",
+          "x-ratelimit-usage": "300,27000"
+         };
+        rateLimiting.updateRateLimits(headers);
+        (rateLimiting.fractionReached()).should.eql(0.9);
+    });
+
+
+    it("should set values to zero when headers are nonsense", function () {
+        var headers = {
+          "x-ratelimit-limit": "xxx",
+          "x-ratelimit-usage": "zzz"
+         };
+        rateLimiting.updateRateLimits(headers)
+        rateLimiting.longTermUsage.should.eql(0);
+        rateLimiting.shortTermUsage.should.eql(0);
+        rateLimiting.longTermLimit.should.eql(0);
+        rateLimiting.shortTermLimit.should.eql(0);
+
+    });
+  });
+
+  describe('#exceeded', function () {
+    it("should exceed limit when short term usage exceeds short term limit", function () {
+      rateLimiting.longTermLimit = 1
+      rateLimiting.longTermUsage = 0
+
+      rateLimiting.shortTermLimit = 100
+      rateLimiting.shortTermUsage = 200
+
+      rateLimiting.exceeded().should.be.true;
+    })
+
+    it("should not exceed rate limit when short usage is less than short term limit", function () {
+      rateLimiting.shortTermLimit = 200
+      rateLimiting.shortTermUsage = 100
+
+      rateLimiting.exceeded().should.be.false;
+    })
+
+    it("should exceed rate limit when long term usage exceeds limit", function () {
+      rateLimiting.shortTermLimit = 1
+      rateLimiting.shortTermUsage = 0
+      rateLimiting.longTermLimit = 100
+      rateLimiting.longTermUsage = 200
+
+      rateLimiting.exceeded().should.be.true;
+    });
+
+    it("should not exceed rate limit when long term usage is less than long term limit", function () {
+      rateLimiting.longTermLimit = 200
+      rateLimiting.longTermUsage = 100
+
+      rateLimiting.exceeded().should.be.be.false;
+    });
+
+
+  });
+});

--- a/test/routes.js
+++ b/test/routes.js
@@ -13,6 +13,8 @@ describe('routes_test', function() {
     before(function(done) {
 
         testHelper.getSampleRoute(function(err,sampleRoute) {
+            if (err)
+              return done(err)
 
             _sampleRoute = sampleRoute;
             done();

--- a/test/segments.js
+++ b/test/segments.js
@@ -10,6 +10,8 @@ describe('segments_test', function() {
     before(function(done) {
 
         testHelper.getSampleSegment(function(err,payload) {
+            if (err)
+              return done(err);
 
             _sampleSegment = payload;
             done();
@@ -21,6 +23,8 @@ describe('segments_test', function() {
         it('should return detailed information about segment (level 3)', function (done) {
 
             strava.segments.get({id:_sampleSegment.id}, function (err, payload) {
+                if (err)
+                  return done(err)
 
                 if (!err) {
                     //console.log(payload);

--- a/test/streams.js
+++ b/test/streams.js
@@ -17,8 +17,10 @@ var _sampleActivity;
 describe('streams_test', function() {
 
     before(function (done) {
+        this.timeout(5000);
 
         testHelper.getSampleActivity(function (err, payload) {
+
              if (err)
                return done(err);
 
@@ -127,6 +129,7 @@ describe('streams_test', function() {
     });
 
     describe('#route()', function () {
+        this.timeout(5000);
 
         it('should return raw data associated to route', function(done) {
             strava.streams.route({

--- a/test/streams.js
+++ b/test/streams.js
@@ -19,6 +19,8 @@ describe('streams_test', function() {
     before(function (done) {
 
         testHelper.getSampleActivity(function (err, payload) {
+             if (err)
+               return done(err);
 
             _sampleActivity = payload;
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,20 +1,28 @@
 var should = require("should")
+    , assert = require("assert")
     , testHelper = require("./_helper");
 
 describe('util_test', function() {
 
     describe('#parseRateLimits', function () {
 
-        it('should parse and return limits', function(done) {
+        var limits;
+        before(function(done) {
+           testHelper.getSampleAthlete(function(err,payload,gotLimits) {
+            if (err)
+              return done(err)
 
-            testHelper.getSampleAthlete(function(err,payload,limits) {
-                limits.should.be.a.Object;
-                limits.shortTermUsage.should.be.a.Number;
-                limits.shortTermLimit.should.be.above(0).and.be.a.Number;
-                limits.longTermUsage.should.be.a.Number;
-                limits.longTermLimit.should.be.above(0).and.be.a.Number;
-                done();
-            })
+             limits = gotLimits || null;
+            done();
+           });
+        });
+
+        it('should parse and return limits', function() {
+          limits.should.be.a.Object;
+          limits.shortTermUsage.should.be.a.Number;
+          limits.shortTermLimit.should.be.above(0).and.be.a.Number;
+          limits.longTermUsage.should.be.a.Number;
+          limits.longTermLimit.should.be.above(0).and.be.a.Number;
         });
     });
 });


### PR DESCRIPTION
The original callback-based API is still supported.

Bluebird promises were used.

Promises resolve with a single value, making the original rate limiting
support awkward to accomodate, since it used an additional value passed
through callbacks.

Several other Strava API clients were reviewed for inspiration for
alternate rate limiting interfaces. I found that Strava had written their
own REST client in Go, and had good rate limiting support. I ported
Strava's API for rate limiting support from Go to JavaScript, including
their tests. This adds two new methods that can be called at any time to
check the rate limiting status:

    // returns true if the most recent request exceeded the rate limit
   strava.rateLimiting.exceeded()

    // returns the current decimal fraction (from 0 to 1) of
   // rate used. The greater of the short and long term limits.
   strava.rateLimiting.fractionReached();

These are necessary for the Promise-based interface, but are also available
to the callback-based interface.

This seems like a substantially better solution than always returning an
extra "limits" object which is rarely used and lacks usual status query
methods.

As part of the refactor, the "parseRateLimits" method was also moved from
"lib/util" til into "./lib/rateLimits".