### PR TITLE
Update util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -185,7 +185,7 @@ util.getQS = function(allowedProps,args) {
         , qs;
 
     for(var i = 0; i < allowedProps.length; i++) {
-        if(args[allowedProps[i]])
+        if(args.hasOwnProperty([allowedProps[i]]))
             qa[allowedProps[i]] = args[allowedProps[i]];
     }
 


### PR DESCRIPTION
Fix a property with a value of 0 ( such as { after: 0 }, when requesting for all strava activities since the dawn of time ) from not being included in a query string.

I found this error when trying to execute this statement. 

```strava.athlete.listActivities({ after: 0})```

The "after" query string was not included because it's value was 0.

