### PR TITLE
Bugfix for when there is no response

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -216,8 +216,11 @@ var _requestHelper = function(options,done) {
             console.log('api call error');
             console.log(err);
         }
-
-        done(err, payload, parseRateLimits(response.headers));
+        if (response && response.headers) {
+            done(err, payload, parseRateLimits(response.headers));
+        } else {
+            done(err, payload, {});
+        }     
     });
 };
 


### PR DESCRIPTION
Seems that the Strava API has some weird behavior where the API is not actually down, just responding without a response causing the below: 
TypeError: Cannot read property 'headers' of undefined at line 220. Haven't dug to deep in your code so you might want to fix it in another way but this should at least guard against that.

My app goes down maybe once a week or something like that because of this.