### PR TITLE
Allow 0 as args value and add arg "context_entries"

### DIFF
--- a/lib/segments.js
+++ b/lib/segments.js
@@ -26,7 +26,10 @@ var _qsAllowedProps = [
   'bounds',
   'activity_type',
   'min_cat',
-  'max_cat'
+  'max_cat',
+  
+  // leaderboard
+  'context_entries'
 ]
 var _updateAllowedProps = [
   // star segment

--- a/lib/segments.js
+++ b/lib/segments.js
@@ -27,7 +27,7 @@ var _qsAllowedProps = [
   'activity_type',
   'min_cat',
   'max_cat',
-  
+
   // leaderboard
   'context_entries'
 ]

--- a/lib/util.js
+++ b/lib/util.js
@@ -161,7 +161,7 @@ util.getPaginationQS = function (args) {
 
   if (page) { qa.page = page }
   /* eslint-disable-next-line */
-  if (per_page) { qa.per_page = per_page }
+  if (per_page !== null) { qa.per_page = per_page }
 
   qs = querystring.stringify(qa)
 
@@ -173,7 +173,7 @@ util.getQS = function (allowedProps, args) {
   var qs
 
   for (var i = 0; i < allowedProps.length; i++) {
-    if (args[allowedProps[i]]) { qa[allowedProps[i]] = args[allowedProps[i]] }
+    if (args.hasOwnProperty(allowedProps[i])) { qa[allowedProps[i]] = args[allowedProps[i]] }
   }
 
   qs = querystring.stringify(qa)
@@ -185,7 +185,7 @@ util.getRequestBodyObj = function (allowedProps, args) {
   var body = {}
 
   for (var i = 0; i < allowedProps.length; i++) {
-    if (args[allowedProps[i]]) { body[allowedProps[i]] = args[allowedProps[i]] }
+    if (args.hasOwnProperty(allowedProps[i])) { body[allowedProps[i]] = args[allowedProps[i]] }
   }
 
   return body


### PR DESCRIPTION
This is especially helpful when calling segment leaderboards. 
"per_page" = 0 and "context_entries" = 0 result in a single entry of the authenticated user.
Includes changes of PR #71 