### PR TITLE
v2 uploads.post fails

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -3,7 +3,6 @@ const Promise = require('bluebird')
 const querystring = require('querystring')
 const fs = require('fs')
 const rateLimiting = require('./rateLimiting')
-const request = require('request-promise')
 
 // request.debug = true
 
@@ -99,31 +98,21 @@ HttpClient.prototype.deleteEndpoint = function (endpoint, args, done) {
 }
 
 //= ==== postUpload =====
-HttpClient.prototype.postUpload = function (args, done) {
-  if (!args) {
-    args = {}
-  }
-
+HttpClient.prototype.postUpload = function (args = {}, done) {
   var options = {
     url: 'uploads',
-    method: 'POST'
+    method: 'POST',
+    formData: {
+      ...args.formData,
+      file: fs.createReadStream(args.file)
+    }
   }
 
   if (args.access_token) {
     options.headers = { Authorization: 'Bearer ' + args.access_token }
   }
 
-  var req = request.post(options, function (err, httpResponse, payload) {
-    done(err, payload)
-  })
-
-  var form = req.form()
-
-  // append the rest of the formData values
-  for (var key in args.formData) {
-    form.append(key, args.formData[key])
-  }
-  form.append('file', fs.createReadStream(args.file))
+  return Promise.resolve(this.request.post(options)).asCallback(done)
 }
 
 //= ==== get pagination query string =====
@@ -199,7 +188,8 @@ HttpClient.prototype._requestHelper = function (options, done) {
       // The newer promise-bsed API updates a global rateLimiting counter
       limits = rateLimiting.updateRateLimits(response.headers)
       return Promise.resolve(response.body)
-    }).asCallback(callback)
+    })
+    .asCallback(callback)
 }
 
 //= ==== helpers =====

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -1,5 +1,5 @@
 var uploads = function (client) {
-  this.client = this
+  this.client = client
 }
 
 var _allowedFormProps = [
@@ -11,7 +11,7 @@ var _allowedFormProps = [
   'data_type'
 ]
 
-uploads.post = function (args, done) {
+uploads.prototype.post = function (args, done) {
   var self = this
 
   // various requirements
@@ -42,7 +42,7 @@ uploads.post = function (args, done) {
   })
 }
 
-uploads._check = function (args, cb) {
+uploads.prototype._check = function (args, cb) {
   var endpoint = 'uploads'
   var self = this
 
@@ -61,7 +61,7 @@ uploads._check = function (args, cb) {
   })
 }
 
-uploads._uploadIsDone = function (args) {
+uploads.prototype._uploadIsDone = function (args) {
   var isDone = false
 
   switch (args.status) {


### PR DESCRIPTION
Since version v2 `uploads.post` failed, it looks like this got missed in the refactor. This adjusts the code to use the `this.request` method for uploads as well. It also simplifies the `postUpload` function based on best practices.

