### PR TITLE
add types path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "Simple wrapper for strava v3 API",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "npx eslint *.js lib test && npx mocha test/*.js",
     "lint": "npx eslint *.js lib test"


### PR DESCRIPTION
This will fixes types for people with less greedy `tsconfig.json`s ( #92 )

See more [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)