### PR TITLE
Fixing param passed to refresh token endpoint

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -106,7 +106,7 @@ oauth.refreshToken = (refreshToken) => {
     json: true,
     simple: true,
     qs: {
-      refresh_token: refreshToken,
+      refresh_token: refreshToken.refresh_token,
       client_id: authenticator.getClientId(),
       client_secret: authenticator.getClientSecret(),
       grant_type: 'refresh_token'


### PR DESCRIPTION
Either I'm missing something or the request to refresh a token is not setup right:

Here: https://github.com/UnbounDev/node-strava-v3/blob/master/lib/oauth.js#L109
The `refresh_token` is passed an object `refreshToken` which means the request fails, instead, passing this works:

```js
refresh_token: refreshToken.refresh_token,
```