### PR TITLE
docs(README): add section on BigInt support for large numeric IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,17 @@ const result = await strava.uploads.post({
 });
 ```
 
+### Large numeric IDs (BigInt support)
+
+Strava activity IDs and other numeric identifiers can exceed JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1). To preserve precision, this library uses [json-bigint](https://www.npmjs.com/package/json-bigint) to parse API responses. Since `JSONbig.parse()` is called with default options, large integers are returned as [bignumber.js](https://www.npmjs.com/package/bignumber.js) `BigNumber` objects (not native JavaScript `BigInt`).
+
+When working with these IDs, you may need to convert them to strings for display or storage:
+
+```js
+const activity = await strava.activities.get({ id: '12345678901234567' });
+console.log(activity.id.toString()); // Use .toString() for display or JSON serialization
+```
+
 ### Rate limits
 
 According to Strava's API each response contains information about rate limits.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-v3",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Simple wrapper for Strava v3 API",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Simply adds documentation to clarify how to work with `json-bigint` implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on handling very large numeric IDs that can exceed safe integer limits, explains representation as big-number objects, and shows patterns and examples for converting IDs to string form for safe display and serialization.
* **Chores**
  * Bumped package version to 4.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->