### PR TITLE
fix(axios): map options.form to URL-encoded body in httpRequest (#196)

### DIFF
--- a/axiosUtility.js
+++ b/axiosUtility.js
@@ -107,10 +107,6 @@ const httpRequest = async (options) => {
       maxRedirects: options.maxRedirects === 0 ? 0 : options.maxRedirects || 5,
       validateStatus: options.simple === false ? () => true : defaultValidateStatus
     }
-    // request/request-promise's `form` option (URL-encoded body) is not
-    // understood by axios out of the box, map it to URLSearchParams data
-    // and the matching Content-Type so endpoints like push_subscriptions
-    // do not POST an empty body (#196).
     if (options.form && options.body === undefined) {
       const params = new URLSearchParams()
       for (const [key, value] of Object.entries(options.form)) {

--- a/axiosUtility.js
+++ b/axiosUtility.js
@@ -108,7 +108,7 @@ const httpRequest = async (options) => {
       validateStatus: options.simple === false ? () => true : defaultValidateStatus
     }
     // request/request-promise's `form` option (URL-encoded body) is not
-    // understood by axios out of the box — map it to URLSearchParams data
+    // understood by axios out of the box, map it to URLSearchParams data
     // and the matching Content-Type so endpoints like push_subscriptions
     // do not POST an empty body (#196).
     if (options.form && options.body === undefined) {

--- a/axiosUtility.js
+++ b/axiosUtility.js
@@ -107,6 +107,23 @@ const httpRequest = async (options) => {
       maxRedirects: options.maxRedirects === 0 ? 0 : options.maxRedirects || 5,
       validateStatus: options.simple === false ? () => true : defaultValidateStatus
     }
+    // request/request-promise's `form` option (URL-encoded body) is not
+    // understood by axios out of the box — map it to URLSearchParams data
+    // and the matching Content-Type so endpoints like push_subscriptions
+    // do not POST an empty body (#196).
+    if (options.form && options.body === undefined) {
+      const params = new URLSearchParams()
+      for (const [key, value] of Object.entries(options.form)) {
+        if (value !== undefined && value !== null) {
+          params.append(key, String(value))
+        }
+      }
+      config.data = params
+      config.headers = {
+        ...config.headers,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    }
     const response = await axiosInstance(/** @type {import('axios').AxiosRequestConfig} */ (config))
     if (options.resolveWithFullResponse) {
       return { headers: response.headers, body: response.data }

--- a/test/pushSubscriptions.js
+++ b/test/pushSubscriptions.js
@@ -109,9 +109,6 @@ describe('pushSubscriptions_test', function () {
       })
     })
 
-    // Regression test for #196: the axios migration dropped the
-    // `options.form` → request body translation, so `pushSubscriptions.create`
-    // POSTed an empty body. Verify the URL-encoded fields are actually sent.
     it('should POST URL-encoded fields, not an empty body', async () => {
       let capturedBody
       nock('https://www.strava.com')
@@ -129,9 +126,6 @@ describe('pushSubscriptions_test', function () {
       })
 
       assert.ok(capturedBody, 'POST body must not be empty')
-      // nock parses URL-encoded bodies into objects when Content-Type
-      // signals form data; assert on the resulting fields rather than the
-      // raw bytes so the test is independent of encoding details.
       assert.strictEqual(capturedBody.callback_url, 'http://you.com/callback/')
       assert.strictEqual(capturedBody.verify_token, 'node-strava-v3')
       assert.strictEqual(capturedBody.client_id, 'test-client-id')

--- a/test/pushSubscriptions.js
+++ b/test/pushSubscriptions.js
@@ -108,6 +108,35 @@ describe('pushSubscriptions_test', function () {
         'updated_at': '2015-04-29T18:11:09.400558047-07:00'
       })
     })
+
+    // Regression test for #196: the axios migration dropped the
+    // `options.form` → request body translation, so `pushSubscriptions.create`
+    // POSTed an empty body. Verify the URL-encoded fields are actually sent.
+    it('should POST URL-encoded fields, not an empty body', async () => {
+      let capturedBody
+      nock('https://www.strava.com')
+        .post('/api/v3/push_subscriptions', function (body) {
+          capturedBody = body
+          return true
+        })
+        .matchHeader('content-type', /application\/x-www-form-urlencoded/)
+        .once()
+        .reply(200, { id: 1 })
+
+      await strava.pushSubscriptions.create({
+        'callback_url': 'http://you.com/callback/',
+        'verify_token': 'node-strava-v3'
+      })
+
+      assert.ok(capturedBody, 'POST body must not be empty')
+      // nock parses URL-encoded bodies into objects when Content-Type
+      // signals form data; assert on the resulting fields rather than the
+      // raw bytes so the test is independent of encoding details.
+      assert.strictEqual(capturedBody.callback_url, 'http://you.com/callback/')
+      assert.strictEqual(capturedBody.verify_token, 'node-strava-v3')
+      assert.strictEqual(capturedBody.client_id, 'test-client-id')
+      assert.strictEqual(capturedBody.client_secret, 'test-client-secret')
+    })
   })
 
   describe('#delete({id:...})', function () {


### PR DESCRIPTION
Closes #196.

The `request` → `axios` migration translated `options.body` to `config.data` but lost the `options.form` path. `pushSubscriptions.create` (and any other call site that hands the payload to the HTTP client as `form`) therefore POSTed an empty body, Strava's `push_subscriptions` endpoint silently rejected the request as missing required fields.

Restore the request-promise semantics: when `options.form` is present and `options.body` is not, build a `URLSearchParams` and set `Content-Type: application/x-www-form-urlencoded`. Existing `body`-based callers continue to use `config.data` unchanged.

Regression test `should POST URL-encoded fields, not an empty body` captures the POST body via `nock` and asserts each form field round-trips, fails on `main` with `actual undefined`, passes after the fix. Existing 8 pushSubscriptions tests + eslint also green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form-encoded requests now include the request body and set the correct application/x-www-form-urlencoded Content-Type header, resolving cases where form payloads were previously sent empty.

* **Tests**
  * Added a regression test to confirm push subscription requests are URL-encoded and include required form fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/node-strava/node-strava-v3/pull/199)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->